### PR TITLE
hotfix: remove layout-specific margin from BackButton

### DIFF
--- a/src/components/common/BackButton.vue
+++ b/src/components/common/BackButton.vue
@@ -64,10 +64,4 @@ const goBack = () => {
   font-weight: 600;
   color: var(--color-main);
 }
-
-@media (max-width: 768px) {
-  .back-button {
-    margin-left: 1rem;
-  }
-}
 </style>


### PR DESCRIPTION
## ✨ Summary

BackButton 컴포넌트에 포함되어 있던 `margin-left: 10%` 스타일을 제거했습니다.

## 📌 배경

BackButton은 위치나 정렬을 책임지지 않고, **뒤로가기 버튼과 타이틀 UI만 담당**하는 것이 이상적입니다.  
불필요한 마진이 포함되면, 사용하는 페이지나 레이아웃에서 정렬이 꼬일 수 있어 레이아웃에서 처리하도록 역할을 분리했습니다.

## 🔧 변경 내용

- `BackButton.vue`의 `.back-button` 클래스에서 `margin-left: 10%` 제거

## ⚠️ 참고/유의사항

- BackButton 위치 조정이 필요한 경우, 사용하는 컴포넌트 또는 레이아웃에서 margin/padding 적용해주세요.
- 추후 커뮤니티/상품 페이지 등 공통으로 사용할 때 충돌이 줄어듭니다.