### PR TITLE
fix: login/logout 브랜치 내 API 경로에 누락된 /api prefix 추가

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -4,7 +4,7 @@ export const authAPI = {
   // 로그인
   login: async (email, password) => {
     try {
-      const response = await api.post('/auth/login', {
+      const response = await api.post('/api/auth/login', {
         email,
         password,
       });
@@ -50,7 +50,7 @@ export const authAPI = {
   // 로그아웃
   logout: async () => {
     try {
-      const response = await api.post('/auth/logout');
+      const response = await api.post('/api/auth/logout');
       return {
         success: true,
         message: '로그아웃 되었습니다.',
@@ -69,7 +69,7 @@ export const authAPI = {
   // 아이디 찾기
   findId: async (name, phoneNumber) => {
     try {
-      const response = await api.post('/auth/find-id', {
+      const response = await api.post('/api/auth/find-id', {
         name,
         phoneNumber,
       });
@@ -109,7 +109,7 @@ export const authAPI = {
   // 비밀번호 찾기
   findPassword: async (name, phoneNumber) => {
     try {
-      const response = await api.post('/auth/find-password', {
+      const response = await api.post('/api/auth/find-password', {
         name,
         phoneNumber,
       });
@@ -149,7 +149,7 @@ export const authAPI = {
   // 비밀번호 재설정
   resetPassword: async (newPassword, newPasswordCheck, username) => {
     try {
-      const response = await api.post('/auth/reset-password', {
+      const response = await api.post('/api/auth/reset-password', {
         newPassword,
         newPasswordCheck,
         username,
@@ -187,7 +187,7 @@ export const authAPI = {
   },
   signup: async (signupData) => {
     try {
-      const response = await api.post('/signup', signupData);
+      const response = await api.post('/api/signup', signupData);
 
       const result = response.data;
       if (result.header?.status === 'CREATED') {
@@ -226,7 +226,7 @@ export const authAPI = {
   //소셜 회원가입
   socialSignup: async (signupData) => {
     try {
-      const response = await api.post('/signup/social', signupData);
+      const response = await api.post('/api/signup/social', signupData);
 
       const result = response.data;
       if (result.header?.status === 'CREATED') {

--- a/src/api/member.js
+++ b/src/api/member.js
@@ -3,7 +3,7 @@ import api from './index';
 export const memberAPI = {
   getMyInfo: async () => {
     try {
-      const response = await api.get('/member/me');
+      const response = await api.get('/api/member/me');
       const result = response.data;
 
       return {
@@ -23,9 +23,7 @@ export const memberAPI = {
 
       return {
         success: false,
-        message:
-          statusMessages[error.response?.status] ||
-          '네트워크 오류가 발생했습니다.',
+        message: statusMessages[error.response?.status] || '네트워크 오류가 발생했습니다.',
         data: null,
       };
     }

--- a/src/api/sms.js
+++ b/src/api/sms.js
@@ -5,7 +5,7 @@ export const smsAPI = {
   sendVerification: async (phoneNumber) => {
     try {
       const response = await api.get(
-        `/sms/send-verification?phoneNumber=${encodeURIComponent(phoneNumber)}`
+        `/api/sms/send-verification?phoneNumber=${encodeURIComponent(phoneNumber)}`
       );
 
       const result = response.data;
@@ -26,9 +26,7 @@ export const smsAPI = {
       console.error('인증번호 발송 API 오류:', error);
       return {
         success: false,
-        message:
-          error.response?.data?.header?.message ||
-          '인증번호 발송에 실패했습니다.',
+        message: error.response?.data?.header?.message || '인증번호 발송에 실패했습니다.',
         data: null,
       };
     }
@@ -37,7 +35,7 @@ export const smsAPI = {
   verifyCode: async (phoneNumber, code) => {
     try {
       const response = await api.post(
-        `/sms/verify-code?phoneNumber=${encodeURIComponent(
+        `/api/sms/verify-code?phoneNumber=${encodeURIComponent(
           phoneNumber
         )}&code=${encodeURIComponent(code)}`
       );
@@ -60,9 +58,7 @@ export const smsAPI = {
       console.error('인증번호 확인 API 오류:', error);
       return {
         success: false,
-        message:
-          error.response?.data?.header?.message ||
-          '인증번호가 일치하지 않습니다.',
+        message: error.response?.data?.header?.message || '인증번호가 일치하지 않습니다.',
         data: null,
       };
     }

--- a/src/api/validation.js
+++ b/src/api/validation.js
@@ -5,7 +5,7 @@ export const validationAPI = {
   checkEmail: async (email) => {
     try {
       const response = await api.get(
-        `/validation/check/email?email=${encodeURIComponent(email)}`
+        `/api/validation/check/email?email=${encodeURIComponent(email)}`
       );
 
       const result = response.data;
@@ -27,8 +27,7 @@ export const validationAPI = {
       return {
         success: false,
         message:
-          error.response?.data?.header?.message ||
-          '이메일 중복 확인 중 오류가 발생했습니다.',
+          error.response?.data?.header?.message || '이메일 중복 확인 중 오류가 발생했습니다.',
         data: null,
       };
     }
@@ -37,7 +36,7 @@ export const validationAPI = {
   checkNickname: async (nickname) => {
     try {
       const response = await api.get(
-        `/validation/check/nickname?nickname=${encodeURIComponent(nickname)}`
+        `/api/validation/check/nickname?nickname=${encodeURIComponent(nickname)}`
       );
 
       const result = response.data;
@@ -59,8 +58,7 @@ export const validationAPI = {
       return {
         success: false,
         message:
-          error.response?.data?.header?.message ||
-          '닉네임 중복 확인 중 오류가 발생했습니다.',
+          error.response?.data?.header?.message || '닉네임 중복 확인 중 오류가 발생했습니다.',
         data: null,
       };
     }


### PR DESCRIPTION
## 📌 변경 내용

- `feature/login-logout` 브랜치에서 작성된 일부 Axios 요청 경로에 `/api` prefix가 누락되어
  프론트에서 요청 시 `404 Not Found`가 발생하는 문제가 있었습니다.
- 본 PR에서는 해당 경로들에 `/api` prefix를 추가하여, 기존 다른 브랜치들과 요청 경로가 일치하도록 수정했습니다.
  
## 🔧 수정 대상

- `src/api/auth.js`, `src/api/member.js`, `src/api/sms.js`, `src/api/validation.js`
- 예시 수정 전: `api.post('/auth/login', ...)`
- 예시 수정 후: `api.post('/api/auth/login', ...)`

## ✅ 테스트

- [x] 로그인 요청 200 OK 응답 확인
- [x] 회원가입 요청 정상 동작 확인
