### PR TITLE
Feature 포트폴리오 및 마이페이지 디자인 개선

### DIFF
--- a/src/components/mypage/account/DeleteConfirmSection.vue
+++ b/src/components/mypage/account/DeleteConfirmSection.vue
@@ -34,7 +34,7 @@
           <i class="fas fa-comment"></i>
           탈퇴 사유를 선택해주세요 (선택사항)
         </label>
-        <div class="custom-select" ref="reasonSelectRef">
+        <div ref="reasonSelectRef" class="custom-select">
           <div
             class="select-trigger"
             :class="{
@@ -292,8 +292,8 @@ onUnmounted(() => {
 
 <style scoped>
 .confirm-section {
-  padding: 2rem;
   border-bottom: 1px solid var(--color-bg-light);
+  padding: 1.5cap 0rem;
 }
 
 .section-title {
@@ -686,10 +686,6 @@ onUnmounted(() => {
 }
 
 @media (max-width: 768px) {
-  .confirm-section {
-    padding: 1.5rem;
-  }
-
   .form-label {
     font-size: 0.7rem;
   }

--- a/src/components/mypage/account/DeleteDataSection.vue
+++ b/src/components/mypage/account/DeleteDataSection.vue
@@ -47,8 +47,8 @@
 
 <style scoped>
 .data-section {
-  padding: 1.5rem;
   border-bottom: 1px solid var(--color-bg-light);
+  padding: 1.5cap 0rem;
 }
 
 .section-title {
@@ -108,10 +108,6 @@
 }
 
 @media (max-width: 768px) {
-  .data-section {
-    padding: 1.5rem;
-  }
-
   .data-list {
     gap: 0.75rem;
   }

--- a/src/components/mypage/account/DeleteWarningSection.vue
+++ b/src/components/mypage/account/DeleteWarningSection.vue
@@ -17,7 +17,6 @@
 
 <style scoped>
 .warning-section {
-  padding: 1.5rem;
   border-bottom: 1px solid var(--color-bg-light);
 }
 
@@ -53,10 +52,6 @@
 }
 
 @media (max-width: 768px) {
-  .warning-section {
-    padding: 1.5rem;
-  }
-
   .warning-header i {
     font-size: 1.25rem;
   }

--- a/src/components/mypage/favorite/ProductItemInfo.vue
+++ b/src/components/mypage/favorite/ProductItemInfo.vue
@@ -38,11 +38,11 @@
         </span>
         <span v-if="favorite.rstvValue" class="detail-tag">
           <i class="fa-solid fa-won-sign"></i>
-          {{ formatAmount(favorite.rstvValue) }}
+          {{ formatAmount(getRstvValue(favorite.rstvValue)) }}
         </span>
         <span v-if="favorite.intrRateType" class="detail-tag">
           <i class="fa-solid fa-chart-line"></i>
-          {{ favorite.intrRateType }}
+          {{ getIntrRateType(favorite.intrRateType) }}
         </span>
       </div>
     </div>
@@ -60,6 +60,19 @@ const props = defineProps({
     default: true, // 즐겨찾기 목록이므로 기본값 true
   },
 });
+
+//s냐 m이냐
+const getRstvValue = (rstvValue) => {
+  if (rstvValue === 'S') return '정액적립식';
+  if (rstvValue === 'F') return '자유적립식';
+  return rstvValue;
+};
+
+const getIntrRateType = (intrRateType) => {
+  if (intrRateType === 'S') return '단리';
+  if (intrRateType === 'M') return '복리';
+  return intrRateType;
+};
 
 const emit = defineEmits(['toggle-favorite']);
 

--- a/src/components/mypage/portfolio/DeleteConfirmModal.vue
+++ b/src/components/mypage/portfolio/DeleteConfirmModal.vue
@@ -138,7 +138,7 @@ watch(
 }
 
 .modal-container {
-  background: linear-gradient(135deg, var(--color-white) 0%, var(--color-bg-light) 100%);
+  background: var(--color-white);
   border-radius: 1rem;
   box-shadow: 0 20px 60px rgba(220, 38, 38, 0.2);
   max-width: 450px;
@@ -151,7 +151,7 @@ watch(
 .modal-header {
   padding: 1rem;
   border-bottom: 1px solid rgba(220, 38, 38, 0.2);
-  background: linear-gradient(135deg, rgba(220, 38, 38, 0.05), rgba(239, 68, 68, 0.05));
+  background: var(--color-bg-light);
 }
 
 .modal-title {
@@ -176,7 +176,7 @@ watch(
   width: 4rem;
   height: 4rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, #fef2f2, #fee2e2);
+  background: var(--color-bg-light);
   border: 3px solid #fecaca;
   display: flex;
   align-items: center;
@@ -219,7 +219,7 @@ watch(
   justify-content: center;
   gap: 0.5rem;
   padding: 0.75rem;
-  background: linear-gradient(135deg, rgba(239, 68, 68, 0.1), rgba(220, 38, 38, 0.1));
+  background: var(--color-bg-light);
   border-radius: 0.5rem;
   border: 1px solid rgba(220, 38, 38, 0.2);
   font-size: 0.85rem;
@@ -234,7 +234,7 @@ watch(
 .modal-footer {
   padding: 1rem;
   border-top: 1px solid rgba(185, 187, 204, 0.2);
-  background: rgba(255, 255, 255, 0.8);
+  background: var(--color-white);
   display: flex;
   gap: 0.75rem;
   justify-content: flex-end;
@@ -274,7 +274,7 @@ watch(
 }
 
 .delete-btn {
-  background: linear-gradient(135deg, #dc2626, #ef4444);
+  background: var(--color-sub);
   color: white;
   border: 2px solid transparent;
 }

--- a/src/components/mypage/portfolio/DeleteConfirmModal.vue
+++ b/src/components/mypage/portfolio/DeleteConfirmModal.vue
@@ -140,12 +140,11 @@ watch(
 .modal-container {
   background: var(--color-white);
   border-radius: 1rem;
-  box-shadow: 0 20px 60px rgba(220, 38, 38, 0.2);
   max-width: 450px;
   width: 100%;
   overflow: hidden;
   animation: slideUp 0.3s ease-out;
-  border: 2px solid rgba(220, 38, 38, 0.1);
+  border: 1px solid rgba(185, 187, 204, 0.3);
 }
 
 .modal-header {
@@ -269,7 +268,6 @@ watch(
 
 .cancel-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(107, 114, 128, 0.3);
   border-color: var(--color-light);
 }
 
@@ -281,7 +279,6 @@ watch(
 
 .delete-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(220, 38, 38, 0.4);
   border-color: #991b1b;
 }
 

--- a/src/components/mypage/portfolio/ProductAddModal.vue
+++ b/src/components/mypage/portfolio/ProductAddModal.vue
@@ -1161,7 +1161,6 @@ watch([() => formData.value.category, () => formData.value.subcategory], () => {
 .modal-container {
   background: var(--color-white);
   border-radius: 1rem; /* 16px */
-  box-shadow: 0 1.25rem 3.75rem rgba(0, 0, 0, 0.3); /* 0 20px 60px */
   max-width: 26.875rem; /* 430px */
   width: 100%;
   max-height: 80svh;
@@ -1297,7 +1296,6 @@ watch([() => formData.value.category, () => formData.value.subcategory], () => {
 .form-input:focus {
   outline: none;
   border-color: var(--color-main);
-  box-shadow: 0 0 0 3px rgba(45, 51, 107, 0.1);
   background: white;
 }
 .form-select {
@@ -1424,7 +1422,6 @@ watch([() => formData.value.category, () => formData.value.subcategory], () => {
 
 .cancel-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(107, 114, 128, 0.3);
 }
 
 .reset-btn {
@@ -1434,7 +1431,6 @@ watch([() => formData.value.category, () => formData.value.subcategory], () => {
 
 .reset-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.3);
 }
 
 .save-btn {
@@ -1444,7 +1440,6 @@ watch([() => formData.value.category, () => formData.value.subcategory], () => {
 
 .save-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(45, 51, 107, 0.3);
 }
 
 /* 애니메이션 */
@@ -1540,7 +1535,6 @@ watch([() => formData.value.category, () => formData.value.subcategory], () => {
 
 .auto-fill-btn.big:not(:disabled):hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(45, 51, 107, 0.15);
 }
 /* ===== AI 자동입력 결과 카드 ===== */
 .auto-fill-result {
@@ -1593,7 +1587,6 @@ watch([() => formData.value.category, () => formData.value.subcategory], () => {
 
 .result-header .apply-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 6px 14px rgba(45, 51, 107, 0.25);
 }
 
 .result-header .clear-btn {
@@ -1747,7 +1740,6 @@ input[type='number'] {
 /* 호버 시 살짝 떠오르게 */
 .auto-fill-result .result-item label:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 10px rgba(45, 51, 107, 0.12);
 }
 
 /* 체크/선택된 라벨 하이라이트 (브라우저가 :has 지원 시 적용) */
@@ -1821,7 +1813,6 @@ input[type='number'] {
 .info-btn:focus {
   outline: none;
   border-color: var(--color-main);
-  box-shadow: 0 4px 12px rgba(45, 51, 107, 0.12);
   color: var(--color-main);
 }
 
@@ -1836,7 +1827,6 @@ input[type='number'] {
   background: #fff;
   border: 1px solid rgba(185, 187, 204, 0.35);
   border-radius: 0.5rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
   color: var(--color-main);
   font-size: 0.78rem;
   line-height: 1.45;

--- a/src/components/mypage/portfolio/ProductAddModal.vue
+++ b/src/components/mypage/portfolio/ProductAddModal.vue
@@ -1159,7 +1159,7 @@ watch([() => formData.value.category, () => formData.value.subcategory], () => {
 
 /* 모달 컨테이너 */
 .modal-container {
-  background: linear-gradient(135deg, var(--color-white) 0%, var(--color-bg-light) 100%);
+  background: var(--color-white);
   border-radius: 1rem; /* 16px */
   box-shadow: 0 1.25rem 3.75rem rgba(0, 0, 0, 0.3); /* 0 20px 60px */
   max-width: 26.875rem; /* 430px */
@@ -1340,7 +1340,7 @@ watch([() => formData.value.category, () => formData.value.subcategory], () => {
 .preview-section {
   margin-top: 1rem; /* 16px */
   padding: 1rem; /* 16px */
-  background: linear-gradient(135deg, rgba(45, 51, 107, 0.05), rgba(125, 129, 162, 0.05));
+  background: var(--color-bg-light);
   border-radius: 0.75rem; /* 12px */
   border: 0.0625rem solid rgba(185, 187, 204, 0.2); /* 1px */
 }
@@ -1390,7 +1390,7 @@ watch([() => formData.value.category, () => formData.value.subcategory], () => {
 .modal-footer {
   padding: 1rem;
   border-top: 1px solid rgba(185, 187, 204, 0.15);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 249, 252, 0.9) 100%);
+  background: var(--color-white);
   display: flex;
   gap: 0.5rem;
   justify-content: flex-end;
@@ -1547,7 +1547,7 @@ watch([() => formData.value.category, () => formData.value.subcategory], () => {
   grid-column: 1 / -1;
   border: 1px solid rgba(185, 187, 204, 0.35);
   border-radius: 0.75rem;
-  background: linear-gradient(135deg, rgba(45, 51, 107, 0.04), rgba(125, 129, 162, 0.04));
+  background: var(--color-bg-light);
   overflow: hidden;
 }
 
@@ -1773,7 +1773,7 @@ input[type='number'] {
 
 /* 적용 금리 행을 조금 더 강조 */
 .auto-fill-result .result-item:last-child {
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.06), rgba(16, 185, 129, 0.03));
+  background: var(--color-bg-light);
   border-color: rgba(16, 185, 129, 0.25);
 }
 

--- a/src/components/mypage/portfolio/ProductDetails.vue
+++ b/src/components/mypage/portfolio/ProductDetails.vue
@@ -945,7 +945,7 @@ const handleDelete = (event) => {
 
 /* 모달 컨테이너 */
 .modal-container {
-  background: linear-gradient(135deg, var(--color-white) 0%, var(--color-bg-light) 100%);
+  background: var(--color-white);
   border-radius: 1rem; /* 16px */
   box-shadow: 0 1.25rem 3.75rem rgba(0, 0, 0, 0.3); /* 0 20px 60px */
   max-width: 35rem; /* 560px - 조금 더 넓게 */
@@ -1035,7 +1035,7 @@ const handleDelete = (event) => {
   justify-content: space-between;
   align-items: center;
   padding: 0.75rem;
-  background: linear-gradient(135deg, rgba(45, 51, 107, 0.05), rgba(125, 129, 162, 0.05));
+  background: var(--color-bg-light);
   border-radius: 0.75rem;
   border: 0.0625rem solid rgba(185, 187, 204, 0.2);
   margin-bottom: 1.5rem;
@@ -1133,60 +1133,60 @@ const handleDelete = (event) => {
 
 /* 기본 아이콘 색상 - 기존 스타일과 통일 */
 .detail-icon.calendar {
-  background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
+  background: var(--color-sub);
 }
 .detail-icon.category {
-  background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
+  background: var(--color-sub);
 }
 .detail-icon.company {
-  background: linear-gradient(135deg, #06b6d4 0%, #0891b2 100%);
+  background: var(--color-sub);
 }
 .detail-icon.duration {
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  background: var(--color-sub);
 }
 .detail-icon.rate {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  background: var(--color-sub);
 }
 .detail-icon.maturity {
-  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+  background: var(--color-sub);
 }
 .detail-icon.profit {
-  background: linear-gradient(135deg, #84cc16 0%, #65a30d 100%);
+  background: var(--color-sub);
 }
 .detail-icon.memo {
-  background: linear-gradient(135deg, #6366f1 0%, #4338ca 100%);
+  background: var(--color-sub);
 }
 .detail-icon.info {
-  background: linear-gradient(135deg, #9ca3af 0%, #6b7280 100%);
+  background: var(--color-sub);
 }
 
 /* 상품별 특수 아이콘 */
 .detail-icon.stock-price {
-  background: linear-gradient(135deg, #ea580c 0%, #c2410c 100%);
+  background: var(--color-sub);
 }
 .detail-icon.market {
-  background: linear-gradient(135deg, #06b6d4 0%, #0891b2 100%);
+  background: var(--color-sub);
 }
 .detail-icon.profit-rate {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  background: var(--color-sub);
 }
 .detail-icon.loss-rate {
-  background: linear-gradient(135deg, #dc2626 0%, #991b1b 100%);
+  background: var(--color-sub);
 }
 .detail-icon.coverage {
-  background: linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%);
+  background: var(--color-sub);
 }
 .detail-icon.beneficiary {
-  background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
+  background: var(--color-sub);
 }
 .detail-icon.pension-type {
-  background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
+  background: var(--color-sub);
 }
 .detail-icon.tax-benefit {
-  background: linear-gradient(135deg, #059669 0%, #047857 100%);
+  background: var(--color-sub);
 }
 .detail-icon.loan-rate {
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  background: var(--color-sub);
 }
 
 .detail-content {
@@ -1266,7 +1266,7 @@ const handleDelete = (event) => {
 
 /* 특별 상태 */
 .info-notice {
-  background: linear-gradient(135deg, rgba(185, 187, 204, 0.1) 0%, rgba(125, 129, 162, 0.1) 100%);
+  background: var(--color-bg-light);
   border: 1px dashed rgba(185, 187, 204, 0.4);
 }
 
@@ -1281,7 +1281,7 @@ const handleDelete = (event) => {
 .modal-footer {
   padding: 0.75rem;
   border-top: 1px solid rgba(185, 187, 204, 0.15);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 249, 252, 0.9) 100%);
+  background: var(--color-white);
   display: flex;
   gap: 0.5rem;
   justify-content: flex-end;

--- a/src/components/mypage/portfolio/ProductDetails.vue
+++ b/src/components/mypage/portfolio/ProductDetails.vue
@@ -947,7 +947,6 @@ const handleDelete = (event) => {
 .modal-container {
   background: var(--color-white);
   border-radius: 1rem; /* 16px */
-  box-shadow: 0 1.25rem 3.75rem rgba(0, 0, 0, 0.3); /* 0 20px 60px */
   max-width: 35rem; /* 560px - 조금 더 넓게 */
   width: 100%;
   max-height: 80svh;
@@ -1046,7 +1045,7 @@ const handleDelete = (event) => {
 }
 
 .amount-value {
-  font-size: 1.25rem;
+  font-size: 1rem;
   font-weight: 700;
   color: #059669;
   margin-bottom: 0.25rem;
@@ -1082,7 +1081,6 @@ const handleDelete = (event) => {
   font-size: 0.6rem;
   font-weight: 600;
   white-space: nowrap;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
 .category-badge i {
@@ -1115,7 +1113,6 @@ const handleDelete = (event) => {
   background: rgba(255, 255, 255, 0.95);
   border-color: rgba(185, 187, 204, 0.3);
   transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(45, 51, 107, 0.08);
 }
 
 .detail-icon {
@@ -1321,7 +1318,6 @@ const handleDelete = (event) => {
 
 .edit-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(45, 51, 107, 0.3);
 }
 
 .delete-btn {
@@ -1331,7 +1327,6 @@ const handleDelete = (event) => {
 
 .delete-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(107, 114, 128, 0.3);
 }
 
 .btn-text {

--- a/src/components/mypage/portfolio/ProductEditForm.vue
+++ b/src/components/mypage/portfolio/ProductEditForm.vue
@@ -971,7 +971,7 @@ watch(
 
 /* 모달 컨테이너 */
 .modal-container {
-  background: linear-gradient(135deg, var(--color-white) 0%, var(--color-bg-light) 100%);
+  background: var(--color-white);
   border-radius: 1rem;
   max-width: 26.875rem;
   width: 100%;
@@ -988,7 +988,7 @@ watch(
   align-items: flex-start;
   padding: 1.5rem;
   border-bottom: 2px solid rgba(185, 187, 204, 0.15);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 249, 252, 0.9) 100%);
+  background: var(--color-white);
 }
 
 .modal-title-section {
@@ -1152,7 +1152,7 @@ watch(
 /* 자동 계산 섹션 */
 .auto-calculate-section {
   padding: 1.25rem;
-  background: linear-gradient(135deg, rgba(45, 51, 107, 0.05), rgba(125, 129, 162, 0.05));
+  background: var(--color-bg-light);
   border-radius: 0.75rem;
   border: 1px solid rgba(185, 187, 204, 0.2);
 }
@@ -1210,7 +1210,7 @@ watch(
 .modal-footer {
   padding: 1rem;
   border-top: 1px solid rgba(185, 187, 204, 0.15);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 249, 252, 0.9) 100%);
+  background: var(--color-white);
   display: flex;
   gap: 0.5rem;
   justify-content: flex-end;

--- a/src/components/mypage/portfolio/ProductEditForm.vue
+++ b/src/components/mypage/portfolio/ProductEditForm.vue
@@ -977,7 +977,6 @@ watch(
   width: 100%;
   max-height: 110vh;
   overflow: hidden;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
   animation: slideUp 0.3s ease-out;
 }
 
@@ -1110,7 +1109,6 @@ watch(
 .form-input:focus {
   outline: none;
   border-color: var(--color-main);
-  box-shadow: 0 0 0 3px rgba(45, 51, 107, 0.1);
   background: white;
 }
 
@@ -1190,7 +1188,6 @@ watch(
 
 .auto-calc-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(125, 129, 162, 0.3);
 }
 
 .calc-note {
@@ -1244,7 +1241,6 @@ watch(
 
 .cancel-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(107, 114, 128, 0.3);
 }
 
 .reset-btn {
@@ -1254,7 +1250,6 @@ watch(
 
 .reset-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.3);
 }
 
 .save-btn {
@@ -1264,7 +1259,6 @@ watch(
 
 .save-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(45, 51, 107, 0.3);
 }
 
 /* 애니메이션 */

--- a/src/components/mypage/portfolio/ProductItem.vue
+++ b/src/components/mypage/portfolio/ProductItem.vue
@@ -492,11 +492,11 @@ const handleDelete = () => {
 }
 
 .product-item.expanded::before {
-  background: linear-gradient(to bottom, var(--color-main) 0%, var(--color-sub) 100%);
+  background: var(--color-main);
 }
 
 .product-item.editing {
-  background: linear-gradient(135deg, rgba(45, 51, 107, 0.08) 0%, rgba(125, 129, 162, 0.08) 100%);
+  background: var(--color-bg-light);
   border-color: var(--color-main);
   cursor: default;
 }

--- a/src/components/mypage/portfolio/ProductItem.vue
+++ b/src/components/mypage/portfolio/ProductItem.vue
@@ -487,7 +487,6 @@ const handleDelete = () => {
   border-radius: 0.75rem;
   margin: 0.5rem auto;
   border: 1px solid rgba(185, 187, 204, 0.4);
-  box-shadow: 0 8px 25px rgba(45, 51, 107, 0.12);
   transform: translateY(-2px);
 }
 
@@ -615,7 +614,6 @@ const handleDelete = () => {
   font-size: 0.6rem;
   font-weight: 600;
   white-space: nowrap;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   transition: all 0.3s ease;
 }
 

--- a/src/components/mypage/portfolio/ProductList.vue
+++ b/src/components/mypage/portfolio/ProductList.vue
@@ -318,7 +318,7 @@ const handleDeleteProduct = (item) => {
 
 <style scoped>
 .products-section {
-  background: linear-gradient(135deg, var(--color-white) 0%, var(--color-bg-light) 100%);
+  background: var(--color-white);
   border-radius: 0.875rem;
   padding: 1.25rem;
   border: 1px solid rgba(185, 187, 204, 0.3);
@@ -511,7 +511,7 @@ const handleDeleteProduct = (item) => {
 
 /* 상품 리스트 */
 .products-list {
-  background: linear-gradient(135deg, var(--color-white) 0%, var(--color-bg-light) 100%);
+  background: var(--color-white);
   border-radius: 1rem;
   border: 1px solid rgba(185, 187, 204, 0.3);
   box-shadow:
@@ -547,7 +547,7 @@ const handleDeleteProduct = (item) => {
 
 /* 검색 결과 없음 */
 .no-results {
-  background: linear-gradient(135deg, var(--color-white) 0%, var(--color-bg-light) 100%);
+  background: var(--color-white);
   border-radius: 1rem;
   border: 2px dashed rgba(185, 187, 204, 0.4);
   padding: 2rem;
@@ -558,7 +558,7 @@ const handleDeleteProduct = (item) => {
   width: 3rem;
   height: 3rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--color-light) 0%, var(--color-sub) 100%);
+  background: var(--color-light);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -604,7 +604,7 @@ const handleDeleteProduct = (item) => {
 
 /* 빈 상태 */
 .empty-state {
-  background: linear-gradient(135deg, var(--color-white) 0%, var(--color-bg-light) 100%);
+  background: var(--color-white);
   border-radius: 1rem;
   border: 2px dashed rgba(185, 187, 204, 0.4);
   padding: 3rem 2rem;
@@ -614,14 +614,14 @@ const handleDeleteProduct = (item) => {
 
 .empty-state:hover {
   border-color: rgba(185, 187, 204, 0.6);
-  background: linear-gradient(135deg, var(--color-bg-light) 0%, var(--color-light) 100%);
+  background: var(--color-bg-light);
 }
 
 .empty-icon {
   width: 4rem;
   height: 4rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--color-light) 0%, var(--color-sub) 100%);
+  background: var(--color-light);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -652,7 +652,7 @@ const handleDeleteProduct = (item) => {
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
-  background: linear-gradient(135deg, var(--color-main) 0%, var(--color-sub) 100%);
+  background: var(--color-main);
   color: white;
   border: none;
   border-radius: 0.75rem;

--- a/src/components/mypage/portfolio/ProductList.vue
+++ b/src/components/mypage/portfolio/ProductList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="products-section mt-4">
-    <!-- 헤더 섹션 -->
-    <div class="products-header">
+    <!-- 헤더 섹션 - 카드 밖으로 분리 -->
+    <div class="section-header">
       <div class="header-content">
         <div class="header-top">
           <h5 class="section-title">
@@ -17,109 +17,137 @@
         </div>
 
         <div class="header-stats">
-          <span class="stats-item">
-            <i class="fas fa-box"></i>
-            총 {{ portfolioItems.length }}개 상품
-          </span>
-          <span class="stats-item">
-            <i class="fas fa-coins"></i>
-            {{ formatTotalAmount() }}
-          </span>
-          <span v-if="portfolioItems.length > 0" class="stats-item">
-            <i class="fas fa-chart-line"></i>
-            평균 {{ formatAverageAmount() }}
-          </span>
+          <div class="stats-card">
+            <span class="stats-item">
+              <i class="fas fa-box"></i>
+              <div class="stats-content">
+                <div class="stats-value">{{ portfolioItems.length }}</div>
+                <div class="stats-label">총 상품</div>
+              </div>
+            </span>
+          </div>
+          <div class="stats-card">
+            <span class="stats-item">
+              <i class="fas fa-coins"></i>
+              <div class="stats-content">
+                <div class="stats-value">{{ formatTotalAmount() }}</div>
+                <div class="stats-label">총 자산</div>
+              </div>
+            </span>
+          </div>
+          <div v-if="portfolioItems.length > 0" class="stats-card">
+            <span class="stats-item">
+              <i class="fas fa-chart-line"></i>
+              <div class="stats-content">
+                <div class="stats-value">{{ formatAverageAmount() }}</div>
+                <div class="stats-label">평균 금액</div>
+              </div>
+            </span>
+          </div>
         </div>
       </div>
     </div>
 
-    <!-- 필터 및 정렬 -->
-    <div v-if="portfolioItems.length > 0" class="list-controls">
+    <!-- 필터 및 정렬 - 독립적인 영역 -->
+    <div v-if="portfolioItems.length > 0" class="controls-section">
       <div class="filter-controls">
-        <select v-model="selectedCategory" class="category-filter">
-          <option value="">전체 카테고리</option>
-          <option v-for="category in availableCategories" :key="category" :value="category">
-            {{ category }}
-          </option>
-        </select>
+        <div class="filter-group">
+          <label>카테고리</label>
+          <select v-model="selectedCategory" class="category-filter">
+            <option value="">전체 카테고리</option>
+            <option v-for="category in availableCategories" :key="category" :value="category">
+              {{ category }}
+            </option>
+          </select>
+        </div>
 
-        <select v-model="sortBy" class="sort-control">
-          <option value="amount-desc">금액 높은순</option>
-          <option value="amount-asc">금액 낮은순</option>
-          <option value="date-desc">최신순</option>
-          <option value="date-asc">오래된순</option>
-          <option value="name-asc">이름순</option>
-        </select>
-      </div>
+        <div class="filter-group">
+          <label>정렬</label>
+          <select v-model="sortBy" class="sort-control">
+            <option value="amount-desc">금액 높은순</option>
+            <option value="amount-asc">금액 낮은순</option>
+            <option value="date-desc">최신순</option>
+            <option value="date-asc">오래된순</option>
+            <option value="name-asc">이름순</option>
+          </select>
+        </div>
 
-      <div class="search-control">
-        <div class="search-input-wrapper">
-          <i class="fas fa-search"></i>
-          <input
-            v-model="searchQuery"
-            type="text"
-            placeholder="상품명 또는 회사명 검색..."
-            class="search-input"
-          />
-          <button v-if="searchQuery" class="clear-search" @click="searchQuery = ''">
-            <i class="fas fa-times"></i>
-          </button>
+        <div class="filter-group search-group">
+          <label>검색</label>
+          <div class="search-input-wrapper">
+            <i class="fas fa-search"></i>
+            <input
+              v-model="searchQuery"
+              type="text"
+              placeholder="상품명 또는 회사명 검색..."
+              class="search-input"
+            />
+            <button v-if="searchQuery" class="clear-search" @click="searchQuery = ''">
+              <i class="fas fa-times"></i>
+            </button>
+          </div>
         </div>
       </div>
     </div>
 
-    <!-- 상품 리스트 -->
-    <div v-if="filteredItems.length > 0" class="products-list" :class="[viewMode]">
-      <template v-for="(item, index) in filteredItems" :key="item.portfolioId">
-        <ProductItem
-          v-if="!isEditing(item)"
-          :item="item"
-          :index="index"
-          :total-items="filteredItems.length"
-          :is-processing="isProcessing"
-          :view-mode="viewMode"
-          @start-edit="handleStartEdit"
-          @save-product="handleSaveProduct"
-          @delete-product="handleDeleteProduct"
-        />
-        <ProductEditForm
-          v-else
-          :item="item"
-          :edit-form="editForm"
-          :is-processing="isProcessing"
-          @save-edit="handleSaveEdit"
-          @cancel-edit="handleCancelEdit"
-        />
-      </template>
+    <!-- 상품 리스트 - 더 넓고 시원하게 -->
+    <div v-if="filteredItems.length > 0" class="products-container">
+      <div class="products-list" :class="[viewMode]">
+        <template v-for="(item, index) in filteredItems" :key="item.portfolioId">
+          <ProductItem
+            v-if="!isEditing(item)"
+            :item="item"
+            :index="index"
+            :total-items="filteredItems.length"
+            :is-processing="isProcessing"
+            :view-mode="viewMode"
+            @start-edit="handleStartEdit"
+            @save-product="handleSaveProduct"
+            @delete-product="handleDeleteProduct"
+          />
+          <ProductEditForm
+            v-else
+            :item="item"
+            :edit-form="editForm"
+            :is-processing="isProcessing"
+            @save-edit="handleSaveEdit"
+            @cancel-edit="handleCancelEdit"
+          />
+        </template>
+      </div>
     </div>
 
     <!-- 검색 결과 없음 -->
     <div v-else-if="portfolioItems.length > 0 && filteredItems.length === 0" class="no-results">
-      <div class="no-results-icon">
-        <i class="fas fa-search"></i>
+      <div class="no-results-content">
+        <div class="no-results-icon">
+          <i class="fas fa-search"></i>
+        </div>
+        <h6 class="no-results-title">검색 결과가 없습니다</h6>
+        <p class="no-results-description">다른 검색어를 시도하거나 필터를 변경해보세요</p>
+        <button class="btn-reset-filters" @click="resetFilters">
+          <i class="fas fa-sync-alt"></i>
+          필터 초기화
+        </button>
       </div>
-      <h6 class="no-results-title">검색 결과가 없습니다</h6>
-      <p class="no-results-description">다른 검색어를 시도하거나 필터를 변경해보세요</p>
-      <button class="btn-reset-filters" @click="resetFilters">
-        <i class="fas fa-sync-alt"></i>
-        필터 초기화
-      </button>
     </div>
 
     <!-- 빈 상태 -->
     <div v-else class="empty-state">
-      <div class="empty-icon">
-        <i class="fas fa-folder-open"></i>
+      <div class="empty-content">
+        <div class="empty-icon">
+          <i class="fas fa-folder-open"></i>
+        </div>
+        <h6 class="empty-title">아직 보유한 상품이 없습니다</h6>
+        <p class="empty-description">
+          첫 번째 투자 상품을 추가하여<br />
+          포트폴리오 관리를 시작해보세요
+        </p>
+        <button class="btn-add-first" @click="handleAddNewProduct">
+          <i class="fas fa-plus"></i>
+          첫 상품 추가하기
+        </button>
       </div>
-      <h6 class="empty-title">아직 보유한 상품이 없습니다</h6>
-      <p class="empty-description">
-        첫 번째 투자 상품을 추가하여<br />
-        포트폴리오 관리를 시작해보세요
-      </p>
-      <button class="btn-add-first" @click="handleAddNewProduct">
-        <i class="fas fa-plus"></i>
-        첫 상품 추가하기
-      </button>
     </div>
   </div>
 </template>
@@ -283,9 +311,7 @@ const handleStartEdit = (item) => {
 const handleSaveProduct = (updatedItem) => {
   if (!isProcessing.value) {
     isProcessing.value = true;
-    emit('save-edit', updatedItem); // 메인 컴포넌트로 전달
-
-    // 처리 완료 후 상태 초기화
+    emit('save-edit', updatedItem);
     setTimeout(() => {
       isProcessing.value = false;
     }, 1000);
@@ -296,7 +322,6 @@ const handleSaveEdit = (item) => {
   if (!isProcessing.value) {
     isProcessing.value = true;
     emit('save-edit', item);
-    // 메인에서 처리 완료 후 isProcessing을 false로 변경
     setTimeout(() => {
       isProcessing.value = false;
     }, 1000);
@@ -318,99 +343,58 @@ const handleDeleteProduct = (item) => {
 
 <style scoped>
 .products-section {
-  background: var(--color-white);
-  border-radius: 0.875rem;
-  padding: 1.25rem;
-  border: 1px solid rgba(185, 187, 204, 0.3);
-  box-shadow:
-    0 4px 6px -1px rgba(45, 51, 107, 0.1),
-    0 2px 4px -1px rgba(45, 51, 107, 0.06);
-  backdrop-filter: blur(10px);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  max-width: 26.875rem;
-
   width: 100%;
-  margin: 0 auto;
+  max-width: none;
+  margin: 0;
+  padding: 0;
 }
 
-/* 헤더 */
-.products-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-  padding-bottom: 1rem;
-  border-bottom: 2px solid rgba(185, 187, 204, 0.2);
+/* 헤더 섹션 - 카드 밖으로 분리 */
+.section-header {
+  border-radius: 1rem;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  border: 1px solid rgba(185, 187, 204, 0.15);
 }
+
 .header-top {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.75rem;
-}
-
-.header-content {
-  flex: 1;
+  margin-bottom: 1.5rem;
 }
 
 .section-title {
   color: var(--color-main);
   font-size: 1rem;
   font-weight: 700;
-  margin: 0 0 0.75rem 0;
+  margin: 0;
   display: flex;
   align-items: center;
 }
 
 .section-title i {
   color: var(--color-sub);
-}
-
-.header-stats {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.stats-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--color-sub);
-  font-size: 0.8rem;
-  font-weight: 500;
-}
-
-.stats-item i {
-  font-size: 0.75rem;
-  opacity: 0.8;
-}
-
-.header-actions {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
+  margin-right: 0.75rem;
 }
 
 .btn-add-product {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.4rem 0.75rem;
+  padding: 0.5rem 1rem;
   background: var(--color-main);
   color: white;
   border: none;
   border-radius: 0.75rem;
-  font-size: 0.6rem;
+  font-size: 0.7rem;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 2px 4px rgba(45, 51, 107, 0.2);
 }
 
 .btn-add-product:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(45, 51, 107, 0.3);
 }
 
 .btn-add-product:disabled {
@@ -418,40 +402,105 @@ const handleDeleteProduct = (item) => {
   cursor: not-allowed;
 }
 
-/* 리스트 컨트롤 */
-.list-controls {
-  flex-direction: column;
-  display: flex;
-  justify-content: space-between;
-  align-items: stretch;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-  padding: 0.75rem;
-  background: rgba(255, 255, 255, 0.8);
+/* 통계 카드들 */
+.header-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.stats-card {
+  background: white;
   border-radius: 0.75rem;
+  padding: 0.5rem;
+  border: 1px solid rgba(185, 187, 204, 0.2);
+  transition: all 0.3s ease;
+}
+
+.stats-card:hover {
+  transform: translateY(-2px);
+}
+
+.stats-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.stats-item i {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.5rem;
+  background: var(--color-main);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.stats-content {
+  flex: 1;
+}
+
+.stats-value {
+  color: var(--color-main);
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.stats-label {
+  color: var(--color-sub);
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+/* 필터 컨트롤 섹션 */
+.controls-section {
+  background: white;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
   border: 1px solid rgba(185, 187, 204, 0.2);
 }
 
 .filter-controls {
+  display: grid;
+  grid-template-columns: 1fr 1fr 2fr;
+  gap: 1.5rem;
+  align-items: end;
+}
+
+.filter-group {
   display: flex;
+  flex-direction: column;
   gap: 0.5rem;
+}
+
+.filter-group label {
+  color: var(--color-main);
+  font-size: 0.875rem;
+  font-weight: 600;
 }
 
 .category-filter,
 .sort-control {
-  padding: 0.4rem 0.75rem;
+  padding: 0.75rem 1rem;
   background: white;
   border: 1px solid rgba(185, 187, 204, 0.3);
   border-radius: 0.5rem;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: var(--color-main);
-  width: 100%;
   cursor: pointer;
+  transition: all 0.3s ease;
 }
 
-.search-control {
-  flex: 1;
-  max-width: none;
+.category-filter:focus,
+.sort-control:focus {
+  outline: none;
+  border-color: var(--color-main);
 }
 
 .search-input-wrapper {
@@ -462,19 +511,26 @@ const handleDeleteProduct = (item) => {
 
 .search-input-wrapper i {
   position: absolute;
-  left: 0.75rem;
+  left: 1rem;
   color: var(--color-sub);
-  font-size: 0.8rem;
+  font-size: 1rem;
+  z-index: 1;
 }
 
 .search-input {
   width: 100%;
-  padding: 0.4rem 0.75rem 0.4rem 2rem;
+  padding: 0.75rem 3rem 0.75rem 2.5rem;
   background: white;
   border: 1px solid rgba(185, 187, 204, 0.3);
   border-radius: 0.5rem;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: var(--color-main);
+  transition: all 0.3s ease;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: var(--color-main);
 }
 
 .search-input::placeholder {
@@ -482,48 +538,37 @@ const handleDeleteProduct = (item) => {
   opacity: 0.8;
 }
 
-.search-input {
-  width: 100%;
-  padding: 0.4rem 2rem 0.4rem 2rem;
-  background: white;
-  border: 1px solid rgba(185, 187, 204, 0.3);
-  border-radius: 0.5rem;
-  font-size: 0.75rem;
-  color: var(--color-main);
-  box-sizing: border-box;
-}
-
 .clear-search {
   position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
+  right: 1rem;
   background: none;
   border: none;
   color: var(--color-sub);
   cursor: pointer;
-  padding: 0.25rem;
+  padding: 0.5rem;
   border-radius: 0.25rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  transition: all 0.3s ease;
 }
 
-/* 상품 리스트 */
+.clear-search:hover {
+  color: var(--color-main);
+  background: rgba(185, 187, 204, 0.1);
+}
+
+/* 상품 컨테이너 - 더 넓고 시원하게 */
+.products-container {
+  margin-bottom: 2rem;
+}
+
 .products-list {
-  background: var(--color-white);
+  background: white;
   border-radius: 1rem;
-  border: 1px solid rgba(185, 187, 204, 0.3);
-  box-shadow:
-    0 4px 6px -1px rgba(45, 51, 107, 0.1),
-    0 2px 4px -1px rgba(45, 51, 107, 0.06);
-  backdrop-filter: blur(10px);
+  border: 1px solid rgba(185, 187, 204, 0.2);
   overflow: hidden;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all 0.3s ease;
 }
 
 .products-list:hover {
-  box-shadow: 0 8px 25px -5px rgba(45, 51, 107, 0.15);
 }
 
 .products-list.card,
@@ -533,7 +578,7 @@ const handleDeleteProduct = (item) => {
 }
 
 .products-list :deep(.product-item) {
-  border-bottom: 1px solid rgba(185, 187, 204, 0.2);
+  border-bottom: 1px solid rgba(185, 187, 204, 0.15);
   transition: all 0.3s ease;
 }
 
@@ -542,82 +587,24 @@ const handleDeleteProduct = (item) => {
 }
 
 .products-list :deep(.product-item:hover) {
-  background: rgba(255, 255, 255, 0.8);
+  background: rgba(45, 51, 107, 0.02);
 }
 
 /* 검색 결과 없음 */
 .no-results {
-  background: var(--color-white);
+  background: white;
   border-radius: 1rem;
-  border: 2px dashed rgba(185, 187, 204, 0.4);
-  padding: 2rem;
+  border: 2px dashed rgba(185, 187, 204, 0.3);
+  padding: 0;
+  overflow: hidden;
+}
+
+.no-results-content {
+  padding: 3rem 2rem;
   text-align: center;
 }
 
 .no-results-icon {
-  width: 3rem;
-  height: 3rem;
-  border-radius: 50%;
-  background: var(--color-light);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 0 auto 1rem;
-}
-
-.no-results-icon i {
-  font-size: 1.25rem;
-  color: white;
-}
-
-.no-results-title {
-  color: var(--color-main);
-  font-size: 1rem;
-  font-weight: 600;
-  margin: 0 0 0.5rem 0;
-}
-
-.no-results-description {
-  color: var(--color-sub);
-  font-size: 0.85rem;
-  margin: 0 0 1rem 0;
-}
-
-.btn-reset-filters {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background: var(--color-sub);
-  color: white;
-  border: none;
-  border-radius: 0.5rem;
-  font-size: 0.8rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.btn-reset-filters:hover {
-  background: var(--color-main);
-}
-
-/* 빈 상태 */
-.empty-state {
-  background: var(--color-white);
-  border-radius: 1rem;
-  border: 2px dashed rgba(185, 187, 204, 0.4);
-  padding: 3rem 2rem;
-  text-align: center;
-  transition: all 0.3s ease;
-}
-
-.empty-state:hover {
-  border-color: rgba(185, 187, 204, 0.6);
-  background: var(--color-bg-light);
-}
-
-.empty-icon {
   width: 4rem;
   height: 4rem;
   border-radius: 50%;
@@ -628,43 +615,122 @@ const handleDeleteProduct = (item) => {
   margin: 0 auto 1.5rem;
 }
 
-.empty-icon i {
-  font-size: 1.75rem;
+.no-results-icon i {
+  font-size: 1.5rem;
   color: white;
 }
 
-.empty-title {
+.no-results-title {
   color: var(--color-main);
   font-size: 1.1rem;
   font-weight: 600;
   margin: 0 0 0.75rem 0;
 }
 
-.empty-description {
+.no-results-description {
   color: var(--color-sub);
   font-size: 0.9rem;
-  line-height: 1.5;
-  margin: 0 0 2rem 0;
+  margin: 0 0 1.5rem 0;
+}
+
+.btn-reset-filters {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  background: var(--color-sub);
+  color: white;
+  border: none;
+  border-radius: 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.btn-reset-filters:hover {
+  background: var(--color-main);
+  transform: translateY(-2px);
+}
+
+/* 빈 상태 */
+.empty-state {
+  background: white;
+  border-radius: 1rem;
+  border: 2px dashed rgba(185, 187, 204, 0.3);
+  padding: 0;
+  transition: all 0.3s ease;
+  overflow: hidden;
+}
+
+.empty-state:hover {
+  border-color: rgba(185, 187, 204, 0.5);
+}
+
+.empty-content {
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.empty-icon {
+  width: 5rem;
+  height: 5rem;
+  border-radius: 50%;
+  background: var(--color-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 2rem;
+}
+
+.empty-icon i {
+  font-size: 2rem;
+  color: white;
+}
+
+.empty-title {
+  color: var(--color-main);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 1rem 0;
+}
+
+.empty-description {
+  color: var(--color-sub);
+  font-size: 1rem;
+  line-height: 1.6;
+  margin: 0 0 2.5rem 0;
 }
 
 .btn-add-first {
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  padding: 1rem 1.5rem;
   background: var(--color-main);
   color: white;
   border: none;
   border-radius: 0.75rem;
-  font-size: 0.85rem;
+  font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 12px rgba(45, 51, 107, 0.2);
+  box-shadow: 0 4px 16px rgba(45, 51, 107, 0.2);
 }
 
 .btn-add-first:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(45, 51, 107, 0.3);
+  transform: translateY(-3px);
+}
+
+/* 반응형 디자인 */
+@media (max-width: 1024px) {
+  .filter-controls {
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+
+  .search-group {
+    grid-column: 1 / -1;
+  }
 }
 </style>

--- a/src/components/mypage/portfolio/ProductList.vue
+++ b/src/components/mypage/portfolio/ProductList.vue
@@ -361,7 +361,7 @@ const handleDeleteProduct = (item) => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
 }
 
 .section-title {
@@ -428,8 +428,8 @@ const handleDeleteProduct = (item) => {
 }
 
 .stats-item i {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2rem;
+  height: 2rem;
   border-radius: 0.5rem;
   background: var(--color-main);
   color: white;
@@ -446,7 +446,7 @@ const handleDeleteProduct = (item) => {
 
 .stats-value {
   color: var(--color-main);
-  font-size: 1.1rem;
+  font-size: 0.9rem;
   font-weight: 700;
   margin-bottom: 0.25rem;
 }
@@ -461,8 +461,8 @@ const handleDeleteProduct = (item) => {
 .controls-section {
   background: white;
   border-radius: 1rem;
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
   border: 1px solid rgba(185, 187, 204, 0.2);
 }
 

--- a/src/components/mypage/portfolio/age/AgeComparisonChart.vue
+++ b/src/components/mypage/portfolio/age/AgeComparisonChart.vue
@@ -157,16 +157,12 @@ const toggleTab = (index) => {
   border-radius: 1rem;
   padding: 1rem;
   border: 1px solid rgba(185, 187, 204, 0.3);
-  box-shadow:
-    0 4px 6px -1px rgba(45, 51, 107, 0.1),
-    0 2px 4px -1px rgba(45, 51, 107, 0.06);
   backdrop-filter: blur(10px);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .stats-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px -5px rgba(45, 51, 107, 0.15);
 }
 
 .stats-header {
@@ -177,7 +173,7 @@ const toggleTab = (index) => {
 
 .stats-title {
   color: var(--color-main);
-  font-size: 1.2rem;
+  font-size: 1em;
   font-weight: 700;
   margin: 0 0 0.5rem 0;
   display: flex;
@@ -314,7 +310,7 @@ const toggleTab = (index) => {
 
 .mobile-category-title {
   color: var(--color-main);
-  font-size: 1.1rem;
+  font-size: 1rem;
   font-weight: 700;
   margin: 0 0 1rem 0;
   text-align: center;

--- a/src/components/mypage/portfolio/age/AgeComparisonChart.vue
+++ b/src/components/mypage/portfolio/age/AgeComparisonChart.vue
@@ -153,7 +153,7 @@ const toggleTab = (index) => {
 
 <style scoped>
 .stats-card {
-  background: linear-gradient(135deg, var(--color-white) 0%, #f8f9fc 100%);
+  background: var(--color-white);
   border-radius: 1rem;
   padding: 1rem;
   border: 1px solid rgba(185, 187, 204, 0.3);
@@ -208,14 +208,14 @@ const toggleTab = (index) => {
 }
 
 .my-bar {
-  background: linear-gradient(90deg, var(--color-main) 0%, var(--color-sub) 100%);
+  background: var(--color-main);
   border-radius: 1rem;
   transition: width 1s ease-out;
   height: 100%;
 }
 
 .avg-bar {
-  background: linear-gradient(90deg, var(--color-light) 0%, var(--color-sub) 100%);
+  background: var(--color-light);
   border-radius: 1rem;
   transition: width 1s ease-out 0.2s;
   height: 100%;
@@ -401,7 +401,7 @@ const toggleTab = (index) => {
 .comparison-message {
   margin-top: 1.5rem;
   padding: 1rem;
-  background: linear-gradient(135deg, rgba(185, 187, 204, 0.1) 0%, rgba(125, 129, 162, 0.1) 100%);
+  background: var(--color-bg-light);
   border-radius: 0.75rem;
   border: 1px solid rgba(185, 187, 204, 0.2);
   display: flex;
@@ -430,7 +430,7 @@ const toggleTab = (index) => {
 .empty-comparison {
   text-align: center;
   padding: 2rem;
-  background: linear-gradient(135deg, rgba(185, 187, 204, 0.1) 0%, rgba(125, 129, 162, 0.1) 100%);
+  background: var(--color-bg-light);
   border-radius: 0.75rem;
   border: 1px solid rgba(185, 187, 204, 0.2);
 }
@@ -439,7 +439,7 @@ const toggleTab = (index) => {
   width: 3rem;
   height: 3rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--color-light) 0%, var(--color-sub) 100%);
+  background: var(--color-light);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/mypage/portfolio/allocation/PortfolioAllocation.vue
+++ b/src/components/mypage/portfolio/allocation/PortfolioAllocation.vue
@@ -29,8 +29,8 @@
               <div v-if="processedSummary.length > 0" class="chart-container">
                 <canvas
                   ref="pieChart"
-                  width="200"
-                  height="200"
+                  width="150"
+                  height="150"
                   :aria-label="getChartAriaLabel()"
                 ></canvas>
 
@@ -354,9 +354,6 @@ onBeforeUnmount(cleanup);
   border-radius: 1rem;
   padding: 0;
   border: 1px solid rgba(185, 187, 204, 0.3);
-  box-shadow:
-    0 4px 6px -1px rgba(45, 51, 107, 0.1),
-    0 2px 4px -1px rgba(45, 51, 107, 0.06);
   backdrop-filter: blur(10px);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   overflow: hidden;
@@ -364,7 +361,6 @@ onBeforeUnmount(cleanup);
 
 .stats-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px -5px rgba(45, 51, 107, 0.15);
 }
 
 /* 접을 수 있는 헤더 스타일 */
@@ -467,7 +463,7 @@ onBeforeUnmount(cleanup);
 
 .stats-title {
   color: var(--color-main);
-  font-size: 1.2rem;
+  font-size: 1rem;
   font-weight: 700;
   margin: 0 0 0.5rem 0;
   font-family:
@@ -512,7 +508,7 @@ onBeforeUnmount(cleanup);
 }
 
 .total-amount {
-  font-size: 1.1rem;
+  font-size: 1rem;
   font-weight: 700;
   color: var(--color-main);
   font-family: 'Pretendard', sans-serif;
@@ -607,11 +603,10 @@ onBeforeUnmount(cleanup);
 }
 
 .legend-color {
-  width: 1.125rem;
-  height: 1.125rem;
+  width: 1rem;
+  height: 1rem;
   border-radius: 0.25rem;
   flex-shrink: 0;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: all 0.3s ease;
 }
 
@@ -621,7 +616,7 @@ onBeforeUnmount(cleanup);
 
 .legend-name {
   color: var(--color-main);
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   font-weight: 600;
 }
 
@@ -631,7 +626,7 @@ onBeforeUnmount(cleanup);
 
 .legend-percentage {
   color: var(--color-main);
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 700;
   margin-bottom: 0.25rem;
   font-family: 'Pretendard', sans-serif;
@@ -700,7 +695,7 @@ onBeforeUnmount(cleanup);
   }
 
   .total-amount-header {
-    font-size: 1rem;
+    font-size: 0.9rem;
   }
 
   .stats-content {

--- a/src/components/mypage/portfolio/allocation/PortfolioAllocation.vue
+++ b/src/components/mypage/portfolio/allocation/PortfolioAllocation.vue
@@ -3,66 +3,79 @@
     <div class="row">
       <!-- 파이 차트 섹션 -->
       <div class="mb-4">
-        <div class="stats-card">
-          <div class="stats-header">
-            <h5 class="stats-title">
-              <i class="bi bi-pie-chart me-2"></i>
-              카테고리별 자산 분배
-            </h5>
-            <small class="stats-subtitle"> 총 {{ processedSummary.length }}개 카테고리 </small>
+        <div class="stats-card collapsible-card">
+          <div class="stats-header collapsible-header" @click="togglePieChart">
+            <div class="header-content">
+              <h5 class="stats-title">
+                <i class="bi bi-pie-chart me-2"></i>
+                카테고리별 자산 분배
+              </h5>
+              <small class="stats-subtitle"> 총 {{ processedSummary.length }}개 카테고리 </small>
+            </div>
+            <div class="header-actions">
+              <div class="total-summary">
+                <div class="total-amount-header">{{ formatCurrency(getTotalAmount()) }}</div>
+                <div class="total-label-header">총 자산</div>
+              </div>
+              <div class="collapse-icon" :class="{ rotated: isPieChartOpen }">
+                <i class="bi bi-chevron-down"></i>
+              </div>
+            </div>
           </div>
 
-          <div class="stats-content">
-            <!-- 차트 영역 -->
-            <div v-if="processedSummary.length > 0" class="chart-container">
-              <canvas
-                ref="pieChart"
-                width="200"
-                height="200"
-                :aria-label="getChartAriaLabel()"
-              ></canvas>
+          <div class="collapsible-content" :class="{ collapsed: !isPieChartOpen }">
+            <div class="stats-content">
+              <!-- 차트 영역 -->
+              <div v-if="processedSummary.length > 0" class="chart-container">
+                <canvas
+                  ref="pieChart"
+                  width="200"
+                  height="200"
+                  :aria-label="getChartAriaLabel()"
+                ></canvas>
 
-              <!-- 중앙 총액 표시 (도넛 차트 중앙) -->
-              <div class="chart-center-info">
-                <div class="total-amount">
-                  {{ formatCurrency(getTotalAmount()) }}
-                </div>
-                <div class="total-label">총 자산</div>
-              </div>
-            </div>
-
-            <!-- 빈 상태 -->
-            <div v-else class="empty-state">
-              <div class="empty-icon">
-                <i class="bi bi-pie-chart"></i>
-              </div>
-              <p class="empty-text">투자 상품이 없습니다.</p>
-              <small class="empty-subtitle">상품을 추가하여 자산 분배를 확인해보세요</small>
-            </div>
-
-            <!-- 범례 -->
-            <div v-if="processedSummary.length > 0" class="chart-legend">
-              <div
-                v-for="(category, index) in processedSummary"
-                :key="category.categoryName"
-                class="legend-item"
-                :class="{ 'legend-hidden': hiddenCategories.has(index) }"
-                @click="toggleCategoryVisibility(index)"
-              >
-                <div class="legend-info">
-                  <div class="legend-indicator">
-                    <div
-                      class="legend-color"
-                      :style="{
-                        backgroundColor: getCategoryColor(category.categoryName),
-                      }"
-                    ></div>
-                    <span class="legend-name">{{ category.categoryName }}</span>
+                <!-- 중앙 총액 표시 (도넛 차트 중앙) -->
+                <div class="chart-center-info">
+                  <div class="total-amount">
+                    {{ formatCurrency(getTotalAmount()) }}
                   </div>
-                  <div class="legend-values">
-                    <div class="legend-percentage">{{ category.ratio.toFixed(1) }}%</div>
-                    <div class="legend-amount">
-                      {{ formatCurrency(category.totalAmount) }}
+                  <div class="total-label">총 자산</div>
+                </div>
+              </div>
+
+              <!-- 빈 상태 -->
+              <div v-else class="empty-state">
+                <div class="empty-icon">
+                  <i class="bi bi-pie-chart"></i>
+                </div>
+                <p class="empty-text">투자 상품이 없습니다.</p>
+                <small class="empty-subtitle">상품을 추가하여 자산 분배를 확인해보세요</small>
+              </div>
+
+              <!-- 범례 -->
+              <div v-if="processedSummary.length > 0" class="chart-legend">
+                <div
+                  v-for="(category, index) in processedSummary"
+                  :key="category.categoryName"
+                  class="legend-item"
+                  :class="{ 'legend-hidden': hiddenCategories.has(index) }"
+                  @click="toggleCategoryVisibility(index)"
+                >
+                  <div class="legend-info">
+                    <div class="legend-indicator">
+                      <div
+                        class="legend-color"
+                        :style="{
+                          backgroundColor: getCategoryColor(category.categoryName),
+                        }"
+                      ></div>
+                      <span class="legend-name">{{ category.categoryName }}</span>
+                    </div>
+                    <div class="legend-values">
+                      <div class="legend-percentage">{{ category.ratio.toFixed(1) }}%</div>
+                      <div class="legend-amount">
+                        {{ formatCurrency(category.totalAmount) }}
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -71,10 +84,11 @@
           </div>
         </div>
       </div>
-
       <!-- 서브카테고리 분석 섹션 -->
       <div>
-        <SubcategoryBreakdown :processed-summary="processedSummary" />
+        <div class="stats-card collapsible-card">
+          <SubcategoryBreakdown :processed-summary="processedSummary" />
+        </div>
       </div>
     </div>
   </div>
@@ -96,8 +110,14 @@ const props = defineProps({
 // 반응형 데이터
 const pieChart = ref(null);
 const hiddenCategories = ref(new Set());
+const isPieChartOpen = ref(true); // 파이차트는 기본적으로 열림
 let chartInstance = null;
 let isChartLoading = ref(false);
+
+// 접기/펼치기 토글 함수들
+const togglePieChart = () => {
+  isPieChartOpen.value = !isPieChartOpen.value;
+};
 
 // 6개 메인 카테고리에 맞춘 색상 팔레트
 const CATEGORY_COLORS = {
@@ -108,6 +128,7 @@ const CATEGORY_COLORS = {
   주식: '#EF4444',
   기타: '#6B7280',
 };
+
 // 색상 가져오기
 const getCategoryColor = (categoryName) => {
   return CATEGORY_COLORS[categoryName] || CATEGORY_COLORS['기타'];
@@ -182,7 +203,7 @@ const loadChartJS = async () => {
 
 // 파이차트 생성
 const createPieChart = async () => {
-  if (!pieChart.value || props.processedSummary.length === 0) return;
+  if (!pieChart.value || props.processedSummary.length === 0 || !isPieChartOpen.value) return;
 
   isChartLoading.value = true;
 
@@ -293,11 +314,20 @@ const cleanup = () => {
   }
 };
 
+// 파이차트가 열릴 때 차트를 다시 생성
+watch(isPieChartOpen, (newValue) => {
+  if (newValue) {
+    nextTick(() => {
+      setTimeout(createPieChart, 300);
+    });
+  }
+});
+
 // 데이터 변경 감지
 watch(
   () => props.processedSummary,
   (newData) => {
-    if (newData && newData.length > 0) {
+    if (newData && newData.length > 0 && isPieChartOpen.value) {
       nextTick(() => {
         setTimeout(createPieChart, 100);
       });
@@ -316,19 +346,20 @@ onBeforeUnmount(cleanup);
 
 <style scoped>
 .tab-pane {
-  min-height: 400px;
+  min-height: 200px;
 }
 
 .stats-card {
   background: var(--color-white);
   border-radius: 1rem;
-  padding: 1rem;
+  padding: 0;
   border: 1px solid rgba(185, 187, 204, 0.3);
   box-shadow:
     0 4px 6px -1px rgba(45, 51, 107, 0.1),
     0 2px 4px -1px rgba(45, 51, 107, 0.06);
   backdrop-filter: blur(10px);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
 }
 
 .stats-card:hover {
@@ -336,10 +367,102 @@ onBeforeUnmount(cleanup);
   box-shadow: 0 8px 25px -5px rgba(45, 51, 107, 0.15);
 }
 
-.stats-header {
-  margin-bottom: 1.5rem;
-  padding-bottom: 1rem;
+/* 접을 수 있는 헤더 스타일 */
+.collapsible-header {
+  margin-bottom: 0;
+  padding: 1.25rem;
   border-bottom: 1px solid rgba(185, 187, 204, 0.2);
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--color-white);
+  transition: all 0.3s ease;
+  user-select: none;
+}
+
+.collapsible-header:hover {
+  background: var(--color-bg-light);
+}
+
+.header-content {
+  flex: 1;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.total-summary {
+  text-align: right;
+}
+
+.total-amount-header {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-main);
+  font-family: 'Pretendard', sans-serif;
+  line-height: 1.2;
+}
+
+.total-label-header {
+  font-size: 0.75rem;
+  color: var(--color-sub);
+  font-weight: 500;
+}
+
+.expand-hint {
+  font-size: 0.85rem;
+  color: var(--color-sub);
+  font-weight: 500;
+}
+
+.collapse-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--color-bg-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  flex-shrink: 0;
+}
+
+.collapse-icon i {
+  color: var(--color-main);
+  font-size: 1rem;
+  transition: transform 0.3s ease;
+}
+
+.collapse-icon.rotated i {
+  transform: rotate(180deg);
+}
+
+.collapsible-header:hover .collapse-icon {
+  background: var(--color-bg-light);
+  transform: scale(1.05);
+}
+
+/* 접을 수 있는 콘텐츠 스타일 */
+.collapsible-content {
+  max-height: 2000px;
+  opacity: 1;
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+}
+
+.collapsible-content.collapsed {
+  max-height: 0;
+  opacity: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.stats-content {
+  padding: 1.5rem;
 }
 
 .stats-title {
@@ -366,10 +489,6 @@ onBeforeUnmount(cleanup);
   font-size: 0.85rem;
 }
 
-.stats-content {
-  padding: 0;
-}
-
 .chart-container {
   position: relative;
   height: 15rem;
@@ -380,6 +499,7 @@ onBeforeUnmount(cleanup);
   background: rgba(255, 255, 255, 0.8);
   border-radius: 0.75rem;
   backdrop-filter: blur(5px);
+  margin-bottom: 1.5rem;
 }
 
 .chart-center-info {
@@ -554,12 +674,37 @@ onBeforeUnmount(cleanup);
 /* 접근성 개선 */
 @media (prefers-reduced-motion: reduce) {
   .legend-item,
-  .analysis-item {
+  .analysis-item,
+  .collapsible-content,
+  .collapse-icon {
     transition: none;
   }
 
   .chart-container.loading::after {
     animation: none;
+  }
+}
+
+/* 반응형 디자인 */
+@media (max-width: 768px) {
+  .collapsible-header {
+    padding: 1rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .total-amount-header {
+    font-size: 1rem;
+  }
+
+  .stats-content {
+    padding: 1rem;
   }
 }
 </style>

--- a/src/components/mypage/portfolio/allocation/PortfolioAllocation.vue
+++ b/src/components/mypage/portfolio/allocation/PortfolioAllocation.vue
@@ -320,7 +320,7 @@ onBeforeUnmount(cleanup);
 }
 
 .stats-card {
-  background: linear-gradient(135deg, var(--color-white) 0%, #f8f9fc 100%);
+  background: var(--color-white);
   border-radius: 1rem;
   padding: 1rem;
   border: 1px solid rgba(185, 187, 204, 0.3);
@@ -412,7 +412,7 @@ onBeforeUnmount(cleanup);
   align-items: center;
   justify-content: center;
   padding: 3rem 1rem;
-  background: linear-gradient(135deg, rgba(185, 187, 204, 0.1) 0%, rgba(125, 129, 162, 0.1) 100%);
+  background: var(--color-bg-light);
   border-radius: 0.75rem;
   margin-bottom: 1.5rem;
 }
@@ -421,7 +421,7 @@ onBeforeUnmount(cleanup);
   width: 3.5rem;
   height: 3.5rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--color-light) 0%, var(--color-sub) 100%);
+  background: var(--color-light);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/mypage/portfolio/allocation/SubcategoryBreakdown.vue
+++ b/src/components/mypage/portfolio/allocation/SubcategoryBreakdown.vue
@@ -1,165 +1,181 @@
 <template>
-  <div class="stats-card">
-    <div class="stats-header">
-      <h5 class="stats-title">
-        <i class="bi bi-stack me-2"></i>
-        세부 카테고리 분포
-      </h5>
-      <small class="stats-subtitle"> 카테고리별 상세 구성 현황 </small>
+  <div class="stats-card collapsible-card">
+    <!-- 메인 헤더 (접기/펼치기 가능) -->
+    <div class="stats-header collapsible-header" @click="toggleMainSection">
+      <div class="header-content">
+        <h5 class="stats-title">
+          <i class="bi bi-stack me-2"></i>
+          세부 카테고리 분포
+        </h5>
+        <small class="stats-subtitle"> 카테고리별 상세 구성 현황 </small>
+      </div>
+      <div class="header-actions">
+        <div class="expand-hint">
+          {{ isMainOpen ? '접기' : '자세히 보기' }}
+        </div>
+        <div class="collapse-icon" :class="{ rotated: isMainOpen }">
+          <i class="bi bi-chevron-down"></i>
+        </div>
+      </div>
     </div>
 
-    <div class="stats-content">
-      <div v-if="processedSummary.length > 0" class="subcategory-breakdown">
-        <!-- 전체 펼치기/접기 버튼 -->
-        <div class="breakdown-controls">
-          <button
-            class="control-button"
-            :disabled="expandedCategories.size === processedSummary.length"
-            @click="expandAll"
-          >
-            <i class="bi bi-arrows-expand me-1"></i>
-            전체 펼치기
-          </button>
-          <button
-            class="control-button"
-            :disabled="expandedCategories.size === 0"
-            @click="collapseAll"
-          >
-            <i class="bi bi-arrows-collapse me-1"></i>
-            전체 접기
-          </button>
-        </div>
+    <!-- 메인 콘텐츠 (접을 수 있음) -->
+    <div class="collapsible-content" :class="{ collapsed: !isMainOpen }">
+      <div class="stats-content">
+        <div v-if="processedSummary.length > 0" class="subcategory-breakdown">
+          <!-- 전체 펼치기/접기 버튼 -->
+          <div class="breakdown-controls">
+            <button
+              class="control-button"
+              :disabled="expandedCategories.size === processedSummary.length"
+              @click="expandAll"
+            >
+              <i class="bi bi-arrows-expand me-1"></i>
+              전체 펼치기
+            </button>
+            <button
+              class="control-button"
+              :disabled="expandedCategories.size === 0"
+              @click="collapseAll"
+            >
+              <i class="bi bi-arrows-collapse me-1"></i>
+              전체 접기
+            </button>
+          </div>
 
-        <div
-          v-for="category in processedSummary"
-          :key="category.categoryName"
-          class="category-group"
-          :class="{ expanded: expandedCategories.has(category.categoryName) }"
-        >
-          <!-- 카테고리 헤더 -->
           <div
-            class="category-header"
-            role="button"
-            :aria-expanded="expandedCategories.has(category.categoryName)"
-            :aria-controls="`subcategory-${category.categoryName}`"
-            @click="toggleCategory(category.categoryName)"
+            v-for="category in processedSummary"
+            :key="category.categoryName"
+            class="category-group"
+            :class="{ expanded: expandedCategories.has(category.categoryName) }"
           >
-            <div class="category-info">
-              <div class="category-badge">
+            <!-- 카테고리 헤더 -->
+            <div
+              class="category-header"
+              role="button"
+              :aria-expanded="expandedCategories.has(category.categoryName)"
+              :aria-controls="`subcategory-${category.categoryName}`"
+              @click="toggleCategory(category.categoryName)"
+            >
+              <div class="category-info">
+                <div class="category-badge">
+                  <div
+                    class="badge-color"
+                    :style="{
+                      backgroundColor: getCategoryColor(category.categoryName),
+                    }"
+                  ></div>
+                  <span class="category-name">{{ category.categoryName }}</span>
+                  <span class="subcategory-count">
+                    {{ category.subcategories?.length || 0 }}개
+                  </span>
+                </div>
+
+                <div class="category-stats">
+                  <div class="category-total">
+                    {{ formatCurrency(category.totalAmount) }}
+                  </div>
+                  <div class="category-ratio">{{ category.ratio.toFixed(1) }}%</div>
+                </div>
+              </div>
+
+              <div class="expand-indicator">
+                <i
+                  :class="[
+                    'bi',
+                    expandedCategories.has(category.categoryName)
+                      ? 'bi-chevron-up'
+                      : 'bi-chevron-down',
+                  ]"
+                ></i>
+              </div>
+            </div>
+
+            <!-- 카테고리 진행률 바 -->
+            <div class="category-progress">
+              <div class="progress-track">
                 <div
-                  class="badge-color"
+                  class="progress-fill"
                   :style="{
+                    width: Math.min(category.ratio, 100) + '%',
                     backgroundColor: getCategoryColor(category.categoryName),
                   }"
                 ></div>
-                <span class="category-name">{{ category.categoryName }}</span>
-                <span class="subcategory-count"> {{ category.subcategories?.length || 0 }}개 </span>
-              </div>
-
-              <div class="category-stats">
-                <div class="category-total">
-                  {{ formatCurrency(category.totalAmount) }}
-                </div>
-                <div class="category-ratio">{{ category.ratio.toFixed(1) }}%</div>
               </div>
             </div>
 
-            <div class="expand-indicator">
-              <i
-                :class="[
-                  'bi',
-                  expandedCategories.has(category.categoryName)
-                    ? 'bi-chevron-up'
-                    : 'bi-chevron-down',
-                ]"
-              ></i>
-            </div>
-          </div>
-
-          <!-- 카테고리 진행률 바 -->
-          <div class="category-progress">
-            <div class="progress-track">
-              <div
-                class="progress-fill"
-                :style="{
-                  width: Math.min(category.ratio, 100) + '%',
-                  backgroundColor: getCategoryColor(category.categoryName),
-                }"
-              ></div>
-            </div>
-          </div>
-
-          <!-- 서브카테고리 리스트 (확장 가능) -->
-          <div
-            :id="`subcategory-${category.categoryName}`"
-            class="subcategory-list"
-            :class="{
-              collapsed: !expandedCategories.has(category.categoryName),
-            }"
-          >
+            <!-- 서브카테고리 리스트 (확장 가능) -->
             <div
-              v-for="(sub, index) in category.subcategories || []"
-              :key="sub.subcategoryName"
-              class="subcategory-item"
-              :style="{ animationDelay: `${index * 0.1}s` }"
+              :id="`subcategory-${category.categoryName}`"
+              class="subcategory-list"
+              :class="{
+                collapsed: !expandedCategories.has(category.categoryName),
+              }"
             >
-              <div class="subcategory-info">
-                <div
-                  class="subcategory-indicator"
-                  :style="{
-                    backgroundColor: adjustColorOpacity(
-                      getCategoryColor(category.categoryName),
-                      0.6
-                    ),
-                  }"
-                ></div>
-                <span class="subcategory-name">{{ sub.subcategoryName }}</span>
-
-                <!-- 서브카테고리 내 비율 표시 -->
-                <div class="subcategory-ratio-bar">
+              <div
+                v-for="(sub, index) in category.subcategories || []"
+                :key="sub.subcategoryName"
+                class="subcategory-item"
+                :style="{ animationDelay: `${index * 0.1}s` }"
+              >
+                <div class="subcategory-info">
                   <div
-                    class="ratio-fill"
+                    class="subcategory-indicator"
                     :style="{
-                      width: Math.min(sub.ratio, 100) + '%',
                       backgroundColor: adjustColorOpacity(
                         getCategoryColor(category.categoryName),
-                        0.4
+                        0.6
                       ),
                     }"
                   ></div>
+                  <span class="subcategory-name">{{ sub.subcategoryName }}</span>
+
+                  <!-- 서브카테고리 내 비율 표시 -->
+                  <div class="subcategory-ratio-bar">
+                    <div
+                      class="ratio-fill"
+                      :style="{
+                        width: Math.min(sub.ratio, 100) + '%',
+                        backgroundColor: adjustColorOpacity(
+                          getCategoryColor(category.categoryName),
+                          0.4
+                        ),
+                      }"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="subcategory-values">
+                  <div class="subcategory-amount">
+                    {{ formatCurrency(sub.totalAmount) }}
+                  </div>
+                  <div class="subcategory-percentage">카테고리 내 {{ sub.ratio.toFixed(1) }}%</div>
+                  <div class="subcategory-global-percentage">
+                    전체 {{ ((category.ratio * sub.ratio) / 100).toFixed(1) }}%
+                  </div>
                 </div>
               </div>
 
-              <div class="subcategory-values">
-                <div class="subcategory-amount">
-                  {{ formatCurrency(sub.totalAmount) }}
-                </div>
-                <div class="subcategory-percentage">카테고리 내 {{ sub.ratio.toFixed(1) }}%</div>
-                <div class="subcategory-global-percentage">
-                  전체 {{ ((category.ratio * sub.ratio) / 100).toFixed(1) }}%
-                </div>
+              <!-- 서브카테고리가 없는 경우 -->
+              <div
+                v-if="!category.subcategories || category.subcategories.length === 0"
+                class="no-subcategories"
+              >
+                <i class="bi bi-info-circle me-2"></i>
+                세부 분류가 없는 단일 카테고리입니다
               </div>
-            </div>
-
-            <!-- 서브카테고리가 없는 경우 -->
-            <div
-              v-if="!category.subcategories || category.subcategories.length === 0"
-              class="no-subcategories"
-            >
-              <i class="bi bi-info-circle me-2"></i>
-              세부 분류가 없는 단일 카테고리입니다
             </div>
           </div>
         </div>
-      </div>
 
-      <!-- 빈 상태 -->
-      <div v-else class="empty-state">
-        <div class="empty-icon">
-          <i class="bi bi-stack"></i>
+        <!-- 빈 상태 -->
+        <div v-else class="empty-state">
+          <div class="empty-icon">
+            <i class="bi bi-stack"></i>
+          </div>
+          <p class="empty-text">분석할 카테고리가 없습니다.</p>
+          <small class="empty-subtitle">투자 상품을 추가해주세요</small>
         </div>
-        <p class="empty-text">분석할 카테고리가 없습니다.</p>
-        <small class="empty-subtitle">투자 상품을 추가해주세요</small>
       </div>
     </div>
   </div>
@@ -178,15 +194,21 @@ const props = defineProps({
 
 // 반응형 데이터
 const expandedCategories = ref(new Set());
+const isMainOpen = ref(false); // 메인 섹션은 기본적으로 닫힌 상태
 
-// 6개 메인 카테고리에 맞춘 색상 팔레트
+// 메인 섹션 토글
+const toggleMainSection = () => {
+  isMainOpen.value = !isMainOpen.value;
+};
+
+// 6개 메인 카테고리에 맞춘 색상 팔레트 (메인 컴포넌트와 통일)
 const CATEGORY_COLORS = {
-  예금: '#2d336b', // 진한 네이비
-  적금: '#5a6085', // 미디엄 네이비
-  보험: '#6b7394', // 그레이 네이비
-  대출: '#9ca0b8', // 라이트 그레이
-  주식: '#7d81a2', // 퍼플 그레이
-  기타: '#8a8ea6', // 중간 그레이
+  예금: '#10B981',
+  적금: '#3B82F6',
+  보험: '#8B5CF6',
+  연금: '#F59E0B',
+  주식: '#EF4444',
+  기타: '#6B7280',
 };
 
 // 색상 가져오기
@@ -269,7 +291,7 @@ watch(
 .stats-card {
   background: var(--color-white);
   border-radius: 1rem;
-  padding: 1.5rem;
+  padding: 0;
   border: 1px solid rgba(185, 187, 204, 0.3);
   box-shadow:
     0 4px 6px -1px rgba(45, 51, 107, 0.1),
@@ -277,12 +299,92 @@ watch(
   backdrop-filter: blur(10px);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   height: fit-content;
+  overflow: hidden;
 }
 
-.stats-header {
-  margin-bottom: 1.5rem;
-  padding-bottom: 1rem;
+.stats-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px -5px rgba(45, 51, 107, 0.15);
+}
+
+/* 접을 수 있는 헤더 스타일 */
+.collapsible-header {
+  margin-bottom: 0;
+  padding: 1.25rem;
   border-bottom: 1px solid rgba(185, 187, 204, 0.2);
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--color-white);
+  transition: all 0.3s ease;
+  user-select: none;
+}
+
+.collapsible-header:hover {
+  background: var(--color-bg-light);
+}
+
+.header-content {
+  flex: 1;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.expand-hint {
+  font-size: 0.85rem;
+  color: var(--color-sub);
+  font-weight: 500;
+}
+
+.collapse-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--color-bg-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  flex-shrink: 0;
+}
+
+.collapse-icon i {
+  color: var(--color-main);
+  font-size: 1rem;
+  transition: transform 0.3s ease;
+}
+
+.collapse-icon.rotated i {
+  transform: rotate(180deg);
+}
+
+.collapsible-header:hover .collapse-icon {
+  background: var(--color-bg-light);
+  transform: scale(1.05);
+}
+
+/* 접을 수 있는 콘텐츠 스타일 */
+.collapsible-content {
+  max-height: 2000px;
+  opacity: 1;
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+}
+
+.collapsible-content.collapsed {
+  max-height: 0;
+  opacity: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.stats-content {
+  padding: 1.5rem;
 }
 
 .stats-title {
@@ -307,10 +409,6 @@ watch(
   color: var(--color-sub);
   font-weight: 500;
   font-size: 0.85rem;
-}
-
-.stats-content {
-  padding: 0;
 }
 
 /* 컨트롤 버튼 */
@@ -575,7 +673,6 @@ watch(
   padding: 3rem 1rem;
   background: var(--color-bg-light);
   border-radius: 0.75rem;
-  margin-bottom: 1.5rem;
 }
 
 .empty-icon {
@@ -607,128 +704,6 @@ watch(
   margin: 0;
 }
 
-/* 요약 정보 */
-.breakdown-summary {
-  margin-top: 1.5rem;
-  padding: 1.5rem;
-  background: var(--color-bg-light);
-  border-radius: 0.75rem;
-  border: 1px solid rgba(185, 187, 204, 0.2);
-}
-
-.summary-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-.summary-item {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem;
-  background: rgba(255, 255, 255, 0.8);
-  border-radius: 0.5rem;
-  border: 1px solid rgba(185, 187, 204, 0.15);
-}
-
-.summary-icon {
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.5rem;
-  background: var(--color-light);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-  font-size: 0.9rem;
-  flex-shrink: 0;
-}
-
-.summary-content {
-  display: flex;
-  flex-direction: column;
-}
-
-.summary-label {
-  color: var(--color-sub);
-  font-size: 0.75rem;
-  font-weight: 500;
-  margin-bottom: 0.125rem;
-}
-
-.summary-value {
-  color: var(--color-main);
-  font-size: 0.9rem;
-  font-weight: 600;
-}
-
-/* 집중도 분석 */
-.concentration-analysis {
-  padding-top: 1rem;
-  border-top: 1px solid rgba(185, 187, 204, 0.2);
-}
-
-.analysis-title {
-  color: var(--color-main);
-  font-size: 1rem;
-  font-weight: 600;
-  margin: 0 0 1rem 0;
-  display: flex;
-  align-items: center;
-}
-
-.analysis-content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.concentration-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.concentration-label {
-  color: var(--color-sub);
-  font-size: 0.85rem;
-  font-weight: 500;
-}
-
-.concentration-badge {
-  padding: 0.25rem 0.75rem;
-  border-radius: 1rem;
-  font-size: 0.75rem;
-  font-weight: 600;
-}
-
-.concentration-badge.excellent {
-  background: #d1fae5;
-  color: #065f46;
-}
-
-.concentration-badge.good {
-  background: #dbeafe;
-  color: #1e40af;
-}
-
-.concentration-badge.average {
-  background: #fef3c7;
-  color: #92400e;
-}
-
-.concentration-badge.poor {
-  background: #fed7d7;
-  color: #c53030;
-}
-
-.concentration-badge.dangerous {
-  background: #fee2e2;
-  color: #991b1b;
-}
-
 /* 애니메이션 */
 @keyframes slideInUp {
   from {
@@ -743,7 +718,19 @@ watch(
 
 /* 반응형 */
 @media (max-width: 768px) {
-  .stats-card {
+  .collapsible-header {
+    padding: 1rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .stats-content {
     padding: 1rem;
   }
 
@@ -765,19 +752,6 @@ watch(
   .subcategory-values {
     width: 100%;
     text-align: left;
-  }
-
-  .breakdown-summary {
-    padding: 1rem;
-  }
-
-  .summary-grid {
-    grid-template-columns: 1fr;
-    gap: 0.75rem;
-  }
-
-  .summary-item {
-    padding: 0.5rem;
   }
 
   .breakdown-controls {
@@ -807,19 +781,15 @@ watch(
     margin-top: 0.5rem;
     max-width: none;
   }
-
-  .concentration-item {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.25rem;
-  }
 }
 
 /* 접근성 개선 */
 @media (prefers-reduced-motion: reduce) {
   .category-group,
   .subcategory-item,
-  .control-button {
+  .control-button,
+  .collapsible-content,
+  .collapse-icon {
     transition: none;
   }
 
@@ -834,11 +804,16 @@ watch(
     display: none;
   }
 
+  .collapsible-header {
+    cursor: default;
+  }
+
   .category-group {
     break-inside: avoid;
   }
 
-  .subcategory-list {
+  .subcategory-list,
+  .collapsible-content {
     max-height: none !important;
     opacity: 1 !important;
   }

--- a/src/components/mypage/portfolio/allocation/SubcategoryBreakdown.vue
+++ b/src/components/mypage/portfolio/allocation/SubcategoryBreakdown.vue
@@ -267,7 +267,7 @@ watch(
 
 <style scoped>
 .stats-card {
-  background: linear-gradient(135deg, var(--color-white) 0%, #f8f9fc 100%);
+  background: var(--color-white);
   border-radius: 1rem;
   padding: 1.5rem;
   border: 1px solid rgba(185, 187, 204, 0.3);
@@ -573,7 +573,7 @@ watch(
   align-items: center;
   justify-content: center;
   padding: 3rem 1rem;
-  background: linear-gradient(135deg, rgba(185, 187, 204, 0.1) 0%, rgba(125, 129, 162, 0.1) 100%);
+  background: var(--color-bg-light);
   border-radius: 0.75rem;
   margin-bottom: 1.5rem;
 }
@@ -582,7 +582,7 @@ watch(
   width: 3.5rem;
   height: 3.5rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--color-light) 0%, var(--color-sub) 100%);
+  background: var(--color-light);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -611,7 +611,7 @@ watch(
 .breakdown-summary {
   margin-top: 1.5rem;
   padding: 1.5rem;
-  background: linear-gradient(135deg, rgba(185, 187, 204, 0.1) 0%, rgba(125, 129, 162, 0.1) 100%);
+  background: var(--color-bg-light);
   border-radius: 0.75rem;
   border: 1px solid rgba(185, 187, 204, 0.2);
 }
@@ -637,7 +637,7 @@ watch(
   width: 2rem;
   height: 2rem;
   border-radius: 0.5rem;
-  background: linear-gradient(135deg, var(--color-light) 0%, var(--color-sub) 100%);
+  background: var(--color-light);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/mypage/portfolio/allocation/SubcategoryBreakdown.vue
+++ b/src/components/mypage/portfolio/allocation/SubcategoryBreakdown.vue
@@ -293,9 +293,6 @@ watch(
   border-radius: 1rem;
   padding: 0;
   border: 1px solid rgba(185, 187, 204, 0.3);
-  box-shadow:
-    0 4px 6px -1px rgba(45, 51, 107, 0.1),
-    0 2px 4px -1px rgba(45, 51, 107, 0.06);
   backdrop-filter: blur(10px);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   height: fit-content;
@@ -304,7 +301,6 @@ watch(
 
 .stats-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px -5px rgba(45, 51, 107, 0.15);
 }
 
 /* 접을 수 있는 헤더 스타일 */
@@ -389,7 +385,7 @@ watch(
 
 .stats-title {
   color: var(--color-main);
-  font-size: 1.2rem;
+  font-size: 1rem;
   font-weight: 700;
   margin: 0 0 0.5rem 0;
   font-family:
@@ -490,10 +486,9 @@ watch(
 }
 
 .badge-color {
-  width: 1.125rem;
-  height: 1.125rem;
+  width: 1rem;
+  height: 1rem;
   border-radius: 0.25rem;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: all 0.3s ease;
 }
 
@@ -503,7 +498,7 @@ watch(
 
 .category-name {
   color: var(--color-main);
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 700;
   font-family: 'Pretendard', sans-serif;
 }
@@ -603,7 +598,6 @@ watch(
   width: 0.5rem;
   height: 0.5rem;
   border-radius: 50%;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 .subcategory-name {

--- a/src/components/mypage/portfolio/overview/PortfolioOverView.vue
+++ b/src/components/mypage/portfolio/overview/PortfolioOverView.vue
@@ -393,9 +393,6 @@ onBeforeUnmount(() => {
   background: var(--color-white);
   border-radius: 1rem;
   padding: 1rem;
-  box-shadow:
-    0 4px 6px -1px rgba(45, 51, 107, 0.1),
-    0 2px 4px -1px rgba(45, 51, 107, 0.06);
   border: 1px solid rgba(185, 187, 204, 0.3);
   backdrop-filter: blur(10px);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -406,7 +403,6 @@ onBeforeUnmount(() => {
 
 .stats-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px -5px rgba(45, 51, 107, 0.15);
 }
 
 .stats-header {
@@ -417,7 +413,7 @@ onBeforeUnmount(() => {
 
 .stats-title {
   color: var(--color-main);
-  font-size: 1.1rem;
+  font-size: 1rem;
   font-weight: 700;
   margin: 0 0 0.5rem 0;
   display: flex;

--- a/src/components/mypage/portfolio/overview/PortfolioOverView.vue
+++ b/src/components/mypage/portfolio/overview/PortfolioOverView.vue
@@ -390,7 +390,7 @@ onBeforeUnmount(() => {
 }
 
 .stats-card {
-  background: linear-gradient(135deg, var(--color-white) 0%, var(--color-bg-light) 100%);
+  background: var(--color-white);
   border-radius: 1rem;
   padding: 1rem;
   box-shadow:
@@ -470,7 +470,7 @@ onBeforeUnmount(() => {
 
 /* 빈 상태 */
 .chart-empty-state {
-  background: linear-gradient(135deg, rgba(185, 187, 204, 0.1) 0%, rgba(125, 129, 162, 0.1) 100%);
+  background: var(--color-bg-light);
   border-radius: 0.75rem;
   padding: 2rem;
   text-align: center;
@@ -480,7 +480,7 @@ onBeforeUnmount(() => {
   width: 3rem;
   height: 3rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--color-light) 0%, var(--color-sub) 100%);
+  background: var(--color-bg-light);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/mypage/portfolio/overview/PortfolioSummaryCard.vue
+++ b/src/components/mypage/portfolio/overview/PortfolioSummaryCard.vue
@@ -158,16 +158,12 @@ const getAverageInsight = () => {
   border-radius: 1rem;
   padding: 1rem;
   border: 1px solid rgba(185, 187, 204, 0.3);
-  box-shadow:
-    0 4px 6px -1px rgba(45, 51, 107, 0.1),
-    0 2px 4px -1px rgba(45, 51, 107, 0.06);
   backdrop-filter: blur(10px);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .summary-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px -5px rgba(45, 51, 107, 0.15);
 }
 
 .summary-grid {
@@ -277,7 +273,7 @@ const getAverageInsight = () => {
 }
 
 .summary-value {
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 700;
   margin: 0 0 0.25rem 0;
   color: var(--color-main);

--- a/src/components/mypage/portfolio/overview/PortfolioSummaryCard.vue
+++ b/src/components/mypage/portfolio/overview/PortfolioSummaryCard.vue
@@ -154,7 +154,7 @@ const getAverageInsight = () => {
 .summary-card {
   max-width: 26.875rem;
   width: 100%;
-  background: linear-gradient(135deg, var(--color-white) 0%, var(--color-bg-light) 100%);
+  background: var(--color-white);
   border-radius: 1rem;
   padding: 1rem;
   border: 1px solid rgba(185, 187, 204, 0.3);
@@ -302,12 +302,7 @@ const getAverageInsight = () => {
 }
 
 .summary-item.loading .summary-value {
-  background: linear-gradient(
-    90deg,
-    var(--color-bg-light) 25%,
-    var(--color-light) 50%,
-    var(--color-bg-light) 75%
-  );
+  background: var(--color-light);
   background-size: 200% 100%;
   animation: loading 1.5s infinite;
   border-radius: 4px;

--- a/src/components/mypage/portfolio/tab/PortfolioTabs.vue
+++ b/src/components/mypage/portfolio/tab/PortfolioTabs.vue
@@ -85,7 +85,7 @@ const indicatorStyle = computed(() => {
 
 .nav-container {
   position: relative;
-  background: linear-gradient(135deg, var(--color-white) 0%, var(--color-bg-light) 100%);
+  background: var(--color-white);
   border-radius: 1rem;
   padding: 0.375rem;
   border: 1px solid rgba(185, 187, 204, 0.3);
@@ -171,7 +171,7 @@ const indicatorStyle = computed(() => {
   left: 0.375rem;
   width: calc(25% - 0.1875rem);
   height: calc(100% - 0.75rem);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.85) 100%);
+  background: var(--color-white);
   border-radius: 0.75rem;
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   z-index: 1;

--- a/src/components/mypage/portfolio/tab/PortfolioTabs.vue
+++ b/src/components/mypage/portfolio/tab/PortfolioTabs.vue
@@ -81,6 +81,7 @@ const indicatorStyle = computed(() => {
 .tab-navigation {
   max-width: 26.875rem;
   width: 100%;
+  margin: 0 auto;
 }
 
 .nav-container {
@@ -93,6 +94,10 @@ const indicatorStyle = computed(() => {
     0 2px 4px -1px rgba(45, 51, 107, 0.1),
     0 1px 2px -1px rgba(45, 51, 107, 0.06);
   backdrop-filter: blur(10px);
+  max-width: 26.875rem;
+  width: 100%;
+
+  margin: 0 auto;
 }
 
 .nav-tabs {

--- a/src/components/mypage/portfolio/tab/PortfolioTabs.vue
+++ b/src/components/mypage/portfolio/tab/PortfolioTabs.vue
@@ -90,9 +90,6 @@ const indicatorStyle = computed(() => {
   border-radius: 1rem;
   padding: 0.375rem;
   border: 1px solid rgba(185, 187, 204, 0.3);
-  box-shadow:
-    0 2px 4px -1px rgba(45, 51, 107, 0.1),
-    0 1px 2px -1px rgba(45, 51, 107, 0.06);
   backdrop-filter: blur(10px);
   max-width: 26.875rem;
   width: 100%;
@@ -154,10 +151,8 @@ const indicatorStyle = computed(() => {
   color: var(--color-main);
   background: rgba(255, 255, 255, 0.9);
   font-weight: 600;
-  box-shadow:
-    0 2px 4px rgba(45, 51, 107, 0.1),
-    0 1px 2px rgba(45, 51, 107, 0.06);
   backdrop-filter: blur(5px);
+  border: 1px solid rgba(185, 187, 204, 0.3);
 }
 
 .nav-tabs .nav-link.active i {

--- a/src/components/mypage/portfolio/wmti/PortfolioWMTI.vue
+++ b/src/components/mypage/portfolio/wmti/PortfolioWMTI.vue
@@ -157,15 +157,11 @@ const toggleTab = (index) => {
   border-radius: 1rem;
   padding: 1rem;
   border: 1px solid rgba(185, 187, 204, 0.3);
-  box-shadow:
-    0 4px 6px -1px rgba(45, 51, 107, 0.1),
-    0 2px 4px -1px rgba(45, 51, 107, 0.06);
   backdrop-filter: blur(10px);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 .stats-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px -5px rgba(45, 51, 107, 0.15);
 }
 .stats-header {
   margin-bottom: 1rem;
@@ -174,7 +170,7 @@ const toggleTab = (index) => {
 }
 .stats-title {
   color: var(--color-main);
-  font-size: 1.2rem;
+  font-size: 1rem;
   font-weight: 700;
   margin: 0 0 0.5rem 0;
   display: flex;
@@ -292,7 +288,7 @@ const toggleTab = (index) => {
 }
 .mobile-category-title {
   color: var(--color-main);
-  font-size: 1.1rem;
+  font-size: 1rem;
   font-weight: 700;
   margin: 0 0 1rem 0;
   text-align: center;

--- a/src/components/mypage/portfolio/wmti/PortfolioWMTI.vue
+++ b/src/components/mypage/portfolio/wmti/PortfolioWMTI.vue
@@ -153,7 +153,7 @@ const toggleTab = (index) => {
 <style scoped>
 /* 카드 기본 스타일 */
 .stats-card {
-  background: linear-gradient(135deg, var(--color-white) 0%, #f8f9fc 100%);
+  background: var(--color-white);
   border-radius: 1rem;
   padding: 1rem;
   border: 1px solid rgba(185, 187, 204, 0.3);
@@ -202,13 +202,13 @@ const toggleTab = (index) => {
 }
 
 .my-bar {
-  background: linear-gradient(90deg, var(--color-main) 0%, var(--color-sub) 100%);
+  background: var(--color-main);
   border-radius: 1rem;
   transition: width 1s ease-out;
   height: 100%;
 }
 .avg-bar {
-  background: linear-gradient(90deg, var(--color-light) 0%, var(--color-sub) 100%);
+  background: var(--color-light);
   border-radius: 1rem;
   transition: width 1s ease-out 0.2s;
   height: 100%;
@@ -364,7 +364,7 @@ const toggleTab = (index) => {
 .empty-comparison {
   text-align: center;
   padding: 2rem;
-  background: linear-gradient(135deg, rgba(185, 187, 204, 0.1) 0%, rgba(125, 129, 162, 0.1) 100%);
+  background: var(--color-bg-light);
   border-radius: 0.75rem;
   border: 1px solid rgba(185, 187, 204, 0.2);
 }
@@ -373,7 +373,7 @@ const toggleTab = (index) => {
   width: 3rem;
   height: 3rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--color-light) 0%, var(--color-sub) 100%);
+  background: var(--color-light);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/mypage/profile/ProfileEditSection.vue
+++ b/src/components/mypage/profile/ProfileEditSection.vue
@@ -256,7 +256,6 @@ const handleConfirmPasswordInput = (event) => {
   width: 100%;
   max-width: 26.875rem; /* 430px */
   margin: 0 auto;
-  padding: 1rem;
   background-color: var(--color-white);
 }
 

--- a/src/components/mypage/profile/ProfileReadOnlySection.vue
+++ b/src/components/mypage/profile/ProfileReadOnlySection.vue
@@ -95,7 +95,6 @@ const formatBirthDate = (dateString) => {
   width: 100%;
   max-width: 26.875rem; /* 430px */
   margin: 0 auto;
-  padding: 1rem;
   background-color: var(--color-white);
 }
 

--- a/src/components/mypage/recentview/RecentViewInfo.vue
+++ b/src/components/mypage/recentview/RecentViewInfo.vue
@@ -38,15 +38,14 @@
         </span>
         <span v-if="product.rstvValue" class="detail-tag">
           <i class="fa-solid fa-won-sign"></i>
-          {{ formatAmount(product.rstvValue) }}
+          {{ formatAmount(getRstvValue(product.rstvValue)) }}
         </span>
         <span v-if="product.intrRateType" class="detail-tag">
           <i class="fa-solid fa-chart-line"></i>
-          {{ product.intrRateType }}
+          {{ getIntrRateType(product.intrRateType) }}
         </span>
       </div>
     </div>
-
   </div>
 </template>
 
@@ -61,6 +60,18 @@ const props = defineProps({
     default: false,
   },
 });
+
+const getIntrRateType = (intrRateType) => {
+  if (intrRateType === 'S') return '단리';
+  if (intrRateType === 'M') return '복리';
+  return intrRateType;
+};
+
+const getRstvValue = (rstvValue) => {
+  if (rstvValue === 'S') return '정액적립식';
+  if (rstvValue === 'F') return '자유적립식';
+  return rstvValue;
+};
 
 const emit = defineEmits(['toggle-favorite']);
 

--- a/src/pages/mypage/Account.vue
+++ b/src/pages/mypage/Account.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="password-verify">
     <div class="verify-container">
+      <BackButton class="mb-3" />
       <!-- 사용자 정보 -->
       <!-- <VerifyUserCard :userInfo="userInfo" /> -->
 
@@ -43,6 +44,7 @@ import VerifySecurityNotice from '@/components/mypage/verify/VerifySecurityNotic
 import VerifyBottomLinks from '@/components/mypage/verify/VerifyBottomLinks.vue';
 import VerifySuccessModal from '@/components/mypage/verify/VerifySuccessModal.vue';
 import { useToast } from '@/composables/useToast';
+import BackButton from '@/components/common/BackButton.vue';
 
 const router = useRouter();
 
@@ -153,24 +155,12 @@ const proceedToEdit = () => {
   width: 100%;
   max-width: 26.875rem; /* 430px */
   margin: 0 auto;
-  padding: 1rem;
   background: var(--color-white);
-  min-height: 100vh;
   display: flex;
   align-items: center;
 }
 
 .verify-container {
   width: 100%;
-}
-
-/* 모바일 최적화 - 작은 화면에서 패딩 조정 */
-@media (max-width: 23.4375rem) {
-  /* 375px */
-  .password-verify {
-    padding: 0.75rem;
-    align-items: flex-start;
-    padding-top: 2rem;
-  }
 }
 </style>

--- a/src/pages/mypage/AccountDelete.vue
+++ b/src/pages/mypage/AccountDelete.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="delete-account">
+    <BackButton class="mb-3" />
     <!-- 경고 메시지 -->
     <DeleteWarningSection />
 
@@ -48,6 +49,7 @@ import DeleteDataSection from '@/components/mypage/account/DeleteDataSection.vue
 import DeleteConfirmSection from '@/components/mypage/account/DeleteConfirmSection.vue';
 import DeleteStartSection from '@/components/mypage/account/DeleteStartSection.vue';
 import DeleteFinalModal from '@/components/mypage/account/DeleteFinalModal.vue';
+import BackButton from '@/components/common/BackButton.vue';
 
 const { showToast } = useToast();
 const authStore = useAuthStore();
@@ -183,16 +185,7 @@ onMounted(() => {
   width: 100%;
   max-width: 26.875rem; /* 430px */
   margin: 0 auto;
-  padding: 1rem;
   background-color: var(--color-white);
   min-height: 100vh;
-}
-
-/* 모바일 최적화 - 작은 화면에서 패딩 조정 */
-@media (max-width: 23.4375rem) {
-  /* 375px */
-  .delete-account {
-    padding: 0.75rem;
-  }
 }
 </style>

--- a/src/pages/mypage/AccountEdit.vue
+++ b/src/pages/mypage/AccountEdit.vue
@@ -423,20 +423,11 @@ onMounted(async () => {
   width: 100%;
   max-width: 26.875rem; /* 430px */
   margin: 0 auto;
-  padding: 1rem;
   background: var(--color-white);
   min-height: 100vh;
 }
 
 .edit-container {
   width: 100%;
-}
-
-/* 모바일 최적화 - 작은 화면에서 패딩 조정 */
-@media (max-width: 23.4375rem) {
-  /* 375px */
-  .edit-profile {
-    padding: 0.75rem;
-  }
 }
 </style>

--- a/src/pages/mypage/Favorites.vue
+++ b/src/pages/mypage/Favorites.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="favorites-container">
+    <BackButton class="mb-3" />
     <LoadingSpinner v-if="loading" />
 
     <ErrorAlert v-else-if="error" :message="error" />
@@ -45,6 +46,7 @@ const { showToast } = useToast();
 import LoadingSpinner from '@/components/mypage/common/LoadingSpinner.vue';
 import ErrorAlert from '@/components/mypage/common/ErrorAlert.vue';
 import Pagination from '@/components/mypage/common/Pagination.vue';
+import BackButton from '@/components/common/BackButton.vue';
 
 // 즐겨찾기 전용 컴포넌트
 import FavoritesFilter from '@/components/mypage/favorite/FavoriteFilters.vue';
@@ -262,7 +264,6 @@ onMounted(() => {
   width: 100%;
   max-width: 26.875rem; /* 430px */
   margin: 0 auto;
-  padding: 1rem;
   background-color: var(--color-white);
   min-height: 100vh;
 }
@@ -273,13 +274,5 @@ onMounted(() => {
 
 .favorites-main {
   width: 100%;
-}
-
-/* 모바일 최적화 - 작은 화면에서 패딩 조정 */
-@media (max-width: 23.4375rem) {
-  /* 375px */
-  .favorites-container {
-    padding: 0.75rem;
-  }
 }
 </style>

--- a/src/pages/mypage/MyComments.vue
+++ b/src/pages/mypage/MyComments.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="my-comments-container">
+    <BackButton class="mb-3" />
     <LoadingSpinner v-if="loading" />
     <ErrorAlert v-else-if="error" :message="error" />
 
@@ -34,6 +35,7 @@ import CommentPostFilter from '@/components/mypage/mycomment/CommentPostFilter.v
 import CommentPostList from '@/components/mypage/mycomment/CommentPostList.vue';
 import { postsAPI } from '@/api/mypost';
 import { useToast } from '@/composables/useToast';
+import BackButton from '@/components/common/BackButton.vue';
 
 const { showToast } = useToast();
 
@@ -197,20 +199,11 @@ defineExpose({ fetchPosts });
   width: 100%;
   max-width: 26.875rem; /* 430px */
   margin: 0 auto;
-  padding: 1rem;
   background-color: var(--color-white);
   min-height: 100vh;
 }
 
 .my-comments-content {
   width: 100%;
-}
-
-/* 모바일 최적화 - 작은 화면에서 패딩 조정 */
-@media (max-width: 23.4375rem) {
-  /* 375px */
-  .my-comments-container {
-    padding: 0.75rem;
-  }
 }
 </style>

--- a/src/pages/mypage/MyLikes.vue
+++ b/src/pages/mypage/MyLikes.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="my-likes-container">
+    <BackButton class="mb-3" />
     <LoadingSpinner v-if="loading" />
     <ErrorAlert v-else-if="error" :message="error" />
 
@@ -35,6 +36,7 @@ import LikePostFilter from '@/components/mypage/mylike/LikePostFilter.vue';
 import LikePostList from '@/components/mypage/mylike/LikePostList.vue';
 import { postsAPI } from '@/api/mypost';
 import { useToast } from '@/composables/useToast';
+import BackButton from '@/components/common/BackButton.vue';
 
 const { showToast } = useToast();
 
@@ -219,20 +221,11 @@ defineExpose({ refreshPost });
   width: 100%;
   max-width: 26.875rem; /* 430px */
   margin: 0 auto;
-  padding: 1rem;
   background-color: var(--color-white);
   min-height: 100vh;
 }
 
 .my-likes-content {
   width: 100%;
-}
-
-/* 모바일 최적화 - 작은 화면에서 패딩 조정 */
-@media (max-width: 23.4375rem) {
-  /* 375px */
-  .my-likes-container {
-    padding: 0.75rem;
-  }
 }
 </style>

--- a/src/pages/mypage/MyPage.vue
+++ b/src/pages/mypage/MyPage.vue
@@ -370,7 +370,6 @@ onUnmounted(() => {
 /* 콘텐츠 영역 */
 .content {
   width: 100%;
-  padding: 1rem 1rem;
   background: var(--color-white);
   min-height: 100vh;
 }

--- a/src/pages/mypage/MyPosts.vue
+++ b/src/pages/mypage/MyPosts.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="my-posts-container">
+    <BackButton class="mb-3" />
     <LoadingSpinner v-if="loading" />
     <ErrorAlert v-else-if="error" :message="error" />
 
@@ -34,6 +35,7 @@ import PostFilter from '@/components/mypage/mypost/PostFilter.vue';
 import PostList from '@/components/mypage/mypost/PostList.vue';
 import { postsAPI } from '@/api/mypost';
 import { useToast } from '@/composables/useToast';
+import BackButton from '@/components/common/BackButton.vue';
 
 const { showToast } = useToast();
 
@@ -189,20 +191,11 @@ defineExpose({ refreshPost });
   width: 100%;
   max-width: 26.875rem; /* 430px */
   margin: 0 auto;
-  padding: 1rem;
   background-color: var(--color-white);
   min-height: 100vh;
 }
 
 .my-posts-content {
   width: 100%;
-}
-
-/* 모바일 최적화 - 작은 화면에서 패딩 조정 */
-@media (max-width: 23.4375rem) {
-  /* 375px */
-  .my-posts-container {
-    padding: 0.75rem;
-  }
 }
 </style>

--- a/src/pages/mypage/MyScrap.vue
+++ b/src/pages/mypage/MyScrap.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="my-scraps-container">
+    <BackButton class="mb-3" />
     <LoadingSpinner v-if="loading" />
     <ErrorAlert v-else-if="error" :message="error" />
 
@@ -34,6 +35,7 @@ import ScrapPostFilter from '@/components/mypage/myscrap/ScrapPostFilter.vue';
 import ScrapPostList from '@/components/mypage/myscrap/ScrapPostList.vue';
 import { postsAPI } from '@/api/mypost';
 import { useToast } from '@/composables/useToast';
+import BackButton from '@/components/common/BackButton.vue';
 
 const { showToast } = useToast();
 
@@ -201,20 +203,11 @@ defineExpose({ refreshPost });
   width: 100%;
   max-width: 26.875rem; /* 430px */
   margin: 0 auto;
-  padding: 1rem;
   background-color: var(--color-white);
   min-height: 100vh;
 }
 
 .my-scraps-content {
   width: 100%;
-}
-
-/* 모바일 최적화 - 작은 화면에서 패딩 조정 */
-@media (max-width: 23.4375rem) {
-  /* 375px */
-  .my-scraps-container {
-    padding: 0.75rem;
-  }
 }
 </style>

--- a/src/pages/mypage/Portfolio.vue
+++ b/src/pages/mypage/Portfolio.vue
@@ -1,81 +1,83 @@
 <template>
-  <BackButton class="mb-3" />
-  <LoadingSpinner v-if="loading" />
+  <div class="portfolio-page">
+    <BackButton class="mb-3" />
+    <LoadingSpinner v-if="loading" />
 
-  <ErrorAlert v-else-if="error" :message="error" />
+    <ErrorAlert v-else-if="error" :message="error" />
 
-  <div v-else>
-    <PortfolioTabs v-model:active-tab="activeTab" />
-    <div v-if="activeTab !== 'overview'" class="tab-actions">
-      <button class="btn-add-product" :disabled="loading" @click="openAddModal">
-        <i class="fas fa-plus"></i>
-        상품 추가
-      </button>
-    </div>
+    <div v-else>
+      <PortfolioTabs v-model:active-tab="activeTab" />
+      <div v-if="activeTab !== 'overview'" class="tab-actions">
+        <button class="btn-add-product" :disabled="loading" @click="openAddModal">
+          <i class="fas fa-plus"></i>
+          상품 추가
+        </button>
+      </div>
 
-    <div class="tab-content">
-      <PortfolioOverview
-        v-if="activeTab === 'overview'"
+      <div class="tab-content">
+        <PortfolioOverview
+          v-if="activeTab === 'overview'"
+          :portfolio-items="portfolioItems"
+          :processed-summary="processedSummary"
+          :total-amount="totalAmount"
+          :average-amount="averageAmount"
+          :top-category="topCategory"
+          :diversity-score="diversityScore"
+          :recent-product="recentProduct"
+        />
+
+        <PortfolioComparison
+          v-else-if="activeTab === 'comparison'"
+          :user-age-group="userAgeGroup"
+          :age-comparison-chart="ageComparisonChart"
+          :total-amount="totalAmount"
+        />
+
+        <PortfolioAllocation
+          v-else-if="activeTab === 'allocation'"
+          :processed-summary="processedSummary"
+        />
+
+        <!-- <PortfolioWMTI  v-else-if="activeTab === 'wmti'":wmtiData="wmtiData" /> -->
+        <PortfolioWMTI
+          v-else-if="activeTab === 'wmti'"
+          :my-w-m-t-i="myWMTI || 'UNKNOWN'"
+          :wmti-comparison-chart="wmtiComparisonChart"
+          :total-amount="totalAmount"
+        />
+      </div>
+
+      <ProductList
+        v-if="activeTab === 'allocation'"
         :portfolio-items="portfolioItems"
-        :processed-summary="processedSummary"
-        :total-amount="totalAmount"
-        :average-amount="averageAmount"
-        :top-category="topCategory"
-        :diversity-score="diversityScore"
-        :recent-product="recentProduct"
+        :editing-item="editingItem"
+        :edit-form="editForm"
+        :show-summary="true"
+        :hide-add-button="false"
+        @add-new-product="openAddModal"
+        @refresh-portfolio="refreshPortfolio"
+        @start-edit="startEdit"
+        @save-edit="saveEdit"
+        @cancel-edit="cancelEdit"
+        @delete-product="deleteProduct"
       />
 
-      <PortfolioComparison
-        v-else-if="activeTab === 'comparison'"
-        :user-age-group="userAgeGroup"
-        :age-comparison-chart="ageComparisonChart"
-        :total-amount="totalAmount"
+      <!-- 상품 추가 모달 -->
+      <ProductAddModal
+        :is-visible="showAddModal"
+        @close="closeAddModal"
+        @add-product="addNewProduct"
       />
 
-      <PortfolioAllocation
-        v-else-if="activeTab === 'allocation'"
-        :processed-summary="processedSummary"
-      />
-
-      <!-- <PortfolioWMTI  v-else-if="activeTab === 'wmti'":wmtiData="wmtiData" /> -->
-      <PortfolioWMTI
-        v-else-if="activeTab === 'wmti'"
-        :my-w-m-t-i="myWMTI || 'UNKNOWN'"
-        :wmti-comparison-chart="wmtiComparisonChart"
-        :total-amount="totalAmount"
+      <!-- 삭제 확인 모달 -->
+      <DeleteConfirmModal
+        :is-visible="showDeleteModal"
+        :product-name="productToDelete?.customProductName || '상품'"
+        :is-processing="isDeleting"
+        @close="closeDeleteModal"
+        @confirm="confirmDelete"
       />
     </div>
-
-    <ProductList
-      v-if="activeTab === 'allocation'"
-      :portfolio-items="portfolioItems"
-      :editing-item="editingItem"
-      :edit-form="editForm"
-      :show-summary="true"
-      :hide-add-button="false"
-      @add-new-product="openAddModal"
-      @refresh-portfolio="refreshPortfolio"
-      @start-edit="startEdit"
-      @save-edit="saveEdit"
-      @cancel-edit="cancelEdit"
-      @delete-product="deleteProduct"
-    />
-
-    <!-- 상품 추가 모달 -->
-    <ProductAddModal
-      :is-visible="showAddModal"
-      @close="closeAddModal"
-      @add-product="addNewProduct"
-    />
-
-    <!-- 삭제 확인 모달 -->
-    <DeleteConfirmModal
-      :is-visible="showDeleteModal"
-      :product-name="productToDelete?.customProductName || '상품'"
-      :is-processing="isDeleting"
-      @close="closeDeleteModal"
-      @confirm="confirmDelete"
-    />
   </div>
 </template>
 
@@ -550,6 +552,13 @@ onMounted(async () => {
 </script>
 
 <style scoped>
+.portfolio-page {
+  width: 100%;
+  max-width: 26.875rem; /* 430px */
+  margin: 0 auto;
+  background-color: var(--color-white);
+  min-height: 100vh;
+}
 .tab-content {
   margin-top: 1rem;
 }

--- a/src/pages/mypage/Portfolio.vue
+++ b/src/pages/mypage/Portfolio.vue
@@ -1,4 +1,5 @@
 <template>
+  <BackButton class="mb-3" />
   <LoadingSpinner v-if="loading" />
 
   <ErrorAlert v-else-if="error" :message="error" />
@@ -98,6 +99,7 @@ import DeleteConfirmModal from '../../components/mypage/portfolio/DeleteConfirmM
 import { portfolioAPI } from '@/api/portfolio';
 import { getWMTIResultAPI } from '@/api/wmti';
 import { useToast } from '@/composables/useToast';
+import BackButton from '@/components/common/BackButton.vue';
 const { showToast } = useToast();
 const route = useRoute(); // 추가
 

--- a/src/pages/mypage/WMTIHistory.vue
+++ b/src/pages/mypage/WMTIHistory.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="wmti-history">
+    <BackButton class="mb-3" />
     <!-- Header -->
     <div class="header">
       <h1>검사 히스토리</h1>
@@ -98,6 +99,7 @@ import { getWMTIHistoryAPI } from '@/api/wmti';
 import router from '@/router';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useToast } from '@/composables/useToast';
+import BackButton from '@/components/common/BackButton.vue';
 
 const { showToast } = useToast();
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -237,6 +237,18 @@ const router = createRouter({
       component: () => import('../pages/NotFound/NotFound.vue'), // NotFound 컴포넌트
     },
   ],
+  scrollBehavior(to, from, savedPosition) {
+    // 뒤로/앞으로 가기일 때는 기존 위치 복원
+    if (savedPosition) {
+      return savedPosition;
+    }
+    // 해시가 있으면 앵커로 이동
+    if (to.hash) {
+      return { el: to.hash, behavior: 'smooth' };
+    }
+    // 그 외에는 항상 최상단
+    return { left: 0, top: 0 };
+  },
 });
 
 // 인증 가드 적용


### PR DESCRIPTION
## #️⃣연관된 이슈

> PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호

- close: #84  #96 
  
## ✅작업 내용

> 이번 PR에서 작업한 내용들을 작성해주세요.

- 전체 백버튼 추가
- 마이페이지레이아웃의 추가로 모든 페이지들이 padding이 한 겹 더 생겨서
각 페이지마다 패딩을 없애줌
- 포트폴리오 자산분배 부분이 너무 길어서 통계자료는 접을 수 있게함
- 상품 리스트도 card형식이 답답함을 유발해서 개선작업
- 마이페이지에서 메뉴 눌러서 페이지 이동시, 위로 올라가지 않고 그대로 남아있는 현상이있음. 이를 개선
- 다른 곳과 통일감을 위해 그라데이션 및 쉐도우 제거

## 📸작업 화면

> 뷰 작업 내용이 포함되었을 경우 캡쳐 화면 첨부를 부탁드립니다.

- 
<img width="367" height="747" alt="image" src="https://github.com/user-attachments/assets/13a5688e-208b-4cca-9232-007d73e017dc" />
<img width="370" height="743" alt="image" src="https://github.com/user-attachments/assets/20aa264b-b60e-447f-b387-409805146f72" />

<img width="363" height="749" alt="image" src="https://github.com/user-attachments/assets/4b4c1ca6-22c2-4e40-b573-338c503cf854" />
<img width="372" height="742" alt="image" src="https://github.com/user-attachments/assets/7910848c-98e1-4584-887b-74fe7ca58162" />
<img width="368" height="741" alt="image" src="https://github.com/user-attachments/assets/f43c66f4-88c0-478d-b17b-05e7c4cad258" />
<img width="366" height="745" alt="image" src="https://github.com/user-attachments/assets/380c1217-d9b8-4e19-9627-03227b969f42" />


## 💖리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
