### PR TITLE
refactor: 상품 상세 페이지의 배치, 즐겨찾기 버튼 로그인 시에만 보이도록 조정

### DIFF
--- a/src/components/products/detail/ProductInfoCard.vue
+++ b/src/components/products/detail/ProductInfoCard.vue
@@ -34,7 +34,7 @@
           </span>
         </div>
       </div>
-      <WishButton />
+      <WishButton v-if="isLoggedIn" />
     </div>
   </div>
 </template>
@@ -42,6 +42,7 @@
 <script setup>
 import { computed } from 'vue';
 import WishButton from '@/components/products/wishlist/WishlistButton.vue';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 const props = defineProps({
   product: { type: Object, required: true },
@@ -51,6 +52,9 @@ const props = defineProps({
   interestTypeName: { type: String, default: '' },
   savingsTypeCode: { type: String, default: null }, // ✨ prop 추가
 });
+
+const authStore = useAuthStore();
+const isLoggedIn = computed(() => authStore.isAuthenticated);
 
 // 금리 유형에 따른 클래스 반환
 const getInterestTypeClass = (typeName) => {

--- a/src/pages/products/ProductCompare.vue
+++ b/src/pages/products/ProductCompare.vue
@@ -514,7 +514,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 2.625rem;
+  height: 2.1rem;
   background-color: var(--color-white);
   padding: 0 0rem;
   border-bottom: 0.0625rem solid #f0f0f0;

--- a/src/pages/products/ProductDetail.vue
+++ b/src/pages/products/ProductDetail.vue
@@ -128,7 +128,6 @@ import ProductFeatures from '@/components/products/detail/ProductFeatures.vue';
 import CompareFloatingBar from '@/components/products/compare/CompareFloatingBar.vue';
 import GptDetailModal from '@/components/products/detail/GptDetailModal.vue';
 import useCompareList from '@/composables/useCompareList';
-import { useToast } from '@/composables/useToast';
 import { resolveCompanyLogo } from '@/constants/companyLogoMap';
 
 const route = useRoute();
@@ -137,7 +136,6 @@ const router = useRouter();
 const product = ref(null);
 const loading = ref(true);
 const error = ref(null);
-const selectedTerm = ref({ name: '', description: '' });
 const showGptDetailModal = ref(false);
 
 const {
@@ -553,9 +551,9 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0rem;
   width: 100%;
-  padding: 0 1rem;
+  padding: 0 0.75rem;
 }
 
 .header-left {
@@ -569,13 +567,15 @@ onMounted(() => {
   gap: 0.375rem;
   background: var(--color-white);
   color: var(--color-main);
+  height: 2.1rem;
   border: 0.0625rem solid var(--color-light);
   border-radius: 1.5rem;
-  padding: 0.5rem 0.875rem;
+  padding: 0.5rem 0.75rem;
   font-size: 0.8125rem;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
+  box-shadow: 0 0.125rem 0.5rem rgba(45, 51, 107, 0.1);
 }
 
 .favorite-btn:hover {
@@ -588,7 +588,6 @@ onMounted(() => {
 
 .favorite-btn .favorite-icon {
   color: #ffd700;
-  font-size: 1rem;
 }
 
 .favorite-btn .btn-text {
@@ -601,9 +600,10 @@ onMounted(() => {
   gap: 0.375rem;
   background: var(--color-white);
   color: var(--color-main);
+  height: 2.1rem;
   border: 0.0625rem solid var(--color-light);
   border-radius: 1.5rem;
-  padding: 0.5rem 0.875rem;
+  padding: 0.5rem 0.75rem;
   font-size: 0.8125rem;
   font-weight: 600;
   cursor: pointer;
@@ -750,7 +750,7 @@ onMounted(() => {
   filter: brightness(110%);
 }
 
-@media (max-width: 26.875rem) {
+@media (max-width: 20rem) {
   .page-header {
     padding: 0 0.75rem;
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호

- close: #[issue number]
  
## ✅작업 내용

> 이번 PR에서 작업한 내용들을 작성해주세요.

- 금융 상품 관심 비로그인시에는 안되도록 처리
- 즐겨찾기로 이동 버튼 height 조절해서 다른 페이지 이동 시 이질감이 없도록 조정

## 📸작업 화면

> 뷰 작업 내용이 포함되었을 경우 캡쳐 화면 첨부를 부탁드립니다.

- 비로그인 / 로그인 시 즐겨찾기 담는 버튼의 유무
- '즐겨찾기 이동', 'AI 요약' 배치 어색하지 않도록 조정

<img width="453" height="798" alt="image" src="https://github.com/user-attachments/assets/7fa20f0d-dd98-41ab-9cf9-9c6c882dad46" />
<img width="432" height="791" alt="image" src="https://github.com/user-attachments/assets/f5c53549-c824-41ee-ba50-31d6b6339b35" />



## 💖리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
