### PR TITLE
Fix/survey result formatted date bug - 검사결과지의 '월' 표시오류 수정.

### DIFF
--- a/src/pages/wmti/SurveyResult.vue
+++ b/src/pages/wmti/SurveyResult.vue
@@ -341,12 +341,10 @@ const formattedDate = computed(() => {
   }
 
   try {
-    // createdAt 배열: [년, 월, 일, 시, 분, 초]
-    // JavaScript Date의 월은 0부터 시작하므로 서버에서 받은 월 값에서 1을 빼줘야 함
     const [year, month, day, hour, minute, second] = createdAt.value;
     const date = new Date(year, month - 1, day, hour, minute, second);
 
-    // 유효한 날짜인지 확인
+    // 유효성검사
     if (isNaN(date.getTime())) {
       console.error('Invalid date from createdAt:', createdAt.value);
       return '제출 시각 오류';


### PR DESCRIPTION
## #️⃣연관된 이슈

> PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호

- close: #103 
  
## ✅작업 내용

> 이번 PR에서 작업한 내용들을 작성해주세요.

-  formattedDate에서 날짜 계산에 문제발생.
->  JavaScript의 Date 생성자에서 월(month)은 0부터 시작하는데, 서버에서 받은 createdAt 배열의 월 값이 1부터 시작

## 📸작업 화면

> 뷰 작업 내용이 포함되었을 경우 캡쳐 화면 첨부를 부탁드립니다.

- 수정전
<img width="601" height="122" alt="image" src="https://github.com/user-attachments/assets/106c8d4a-327c-4074-bbf7-2c40deb23596" />

- 수정후
<img width="240" height="52" alt="image" src="https://github.com/user-attachments/assets/c280a5ff-12ad-4bb7-9562-1281b4ebbfa2" />


## 💖리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
